### PR TITLE
[GIT PULL] Three bug fixes for the DNS library

### DIFF
--- a/src/gwproxy/dns.c
+++ b/src/gwproxy/dns.c
@@ -720,8 +720,13 @@ int gwp_dns_cache_lookup(struct gwp_dns_ctx *ctx, const char *name,
 	found_expired = false;
 	for (i = 0; i < cache->nr; i++) {
 		struct cache_entry *e = &cache->entries[i];
+		bool exp = (e->expired_at <= now);
 
-		found_expired |= (e->expired_at <= now);
+		found_expired |= exp;
+
+		if (exp)
+			continue;
+
 		if (strcmp(e->name, name) || strcmp(e->service, service))
 			continue;
 

--- a/src/gwproxy/dns.c
+++ b/src/gwproxy/dns.c
@@ -727,7 +727,12 @@ int gwp_dns_cache_lookup(struct gwp_dns_ctx *ctx, const char *name,
 		if (exp)
 			continue;
 
-		if (strcmp(e->name, name) || strcmp(e->service, service))
+		if (strcmp(e->name, name))
+			continue;
+
+		if (service && strcmp(e->service, service))
+			continue;
+		else if (!service && e->service[0] != '\0')
 			continue;
 
 		if (iterate_addr_list(e->res, addr, ctx->cfg.restyp)) {


### PR DESCRIPTION
Three bug fixes in this series:

**1) Fix missing `expired_at` check in `gwp_dns_cache_lookup()`.**

Expired entries should not be used. Make sure `gwp_dns_cache_lookup()`
skip expired entries.

**2) Fix service comparison bug in `gwp_dns_cache_lookup()`.**

The code assumes service is always non-NULL in comparisons, but it can
be NULL (e.g., no port). Make sure to properly handle that scenario.

**3) Check `gai_error()` first before iterating the addr list.**

In batch dispatch, if `getaddrinfo_a()` fails globally `(r != 0)`, all
entries get `e->res = r`, but individual errors via `gai_error()` are
only checked if `!r`.

In batch success case `(!r)`, `set e->res = gai_error(dbq->reqs[i])`
is set only if iterate fails, else 0. But if `!r` but individual error,
`gai_error()` might be non-zero, check it always.

```
The following changes since commit 18ccd8133f3316dbf593d89e315e6889676cb390:

  gwproxy/dns: Handle `getaddrinfo_a()` error (2025-07-17 12:54:42 +0700)

are available in the Git repository at:

  https://github.com/ammarfaizi2/gwproxy.git dns

for you to fetch changes up to 675a0f3b16bd3fb6c01b60bf397ed82b823d846c:

  gwproxy/dns: Check `gai_error()` first before iterating the addr list (2025-07-17 13:46:02 +0700)

----------------------------------------------------------------
Ammar Faizi (3):
      gwproxy/dns: Fix missing `expired_at` check in `gwp_dns_cache_lookup()`
      gwproxy/dns: Fix service comparison bug in `gwp_dns_cache_lookup()`
      gwproxy/dns: Check `gai_error()` first before iterating the addr list

 src/gwproxy/dns.c | 28 ++++++++++++++++++++--------
 1 file changed, 20 insertions(+), 8 deletions(-)
```
