### PR TITLE
[GIT PULL] Fix various socks5 bugs

### DIFF
--- a/src/gwproxy/dns.c
+++ b/src/gwproxy/dns.c
@@ -616,7 +616,7 @@ static void process_queue_entry(struct gwp_dns_ctx *ctx)
 	 * clone() for each entry if we can process them in the current
 	 * thread.
 	 */
-	if ((ctx->nr_entries + 16) > ctx->nr_sleeping)
+	if (ctx->nr_entries > (ctx->nr_sleeping + 16))
 		process_queue_entry_batch(ctx);
 	else
 		process_queue_entry_single(ctx);

--- a/src/gwproxy/gwproxy.c
+++ b/src/gwproxy/gwproxy.c
@@ -2838,12 +2838,15 @@ static int handle_ev_client_socks5(struct gwp_wrk *w,
 			return sr;
 	}
 
-	r = handle_socks5_data(w, gcp);
-	if (gcp->target.len) {
-		r = handle_socks5_pollout(w, gcp);
-		if (r && r != -EAGAIN)
-			return r;
+	if (gcp->conn_state == CONN_STATE_SOCKS5_DATA) {
+		r = handle_socks5_data(w, gcp);
+		if (gcp->target.len) {
+			r = handle_socks5_pollout(w, gcp);
+			if (r && r != -EAGAIN)
+				return r;
+		}
 	}
+
 	return r;
 }
 

--- a/src/gwproxy/gwproxy.c
+++ b/src/gwproxy/gwproxy.c
@@ -2789,11 +2789,10 @@ static int handle_socks5_data(struct gwp_wrk *w, struct gwp_conn_pair *gcp)
 	out = gcp->target.buf + gcp->target.len;
 	out_len = gcp->target.cap - gcp->target.len;
 	r = gwp_socks5_conn_handle_data(sc, in, &in_len, out, &out_len);
-	if (r)
-		return (r == -EAGAIN) ? 0 : r;
-
 	gwp_conn_buf_advance(&gcp->client, in_len);
 	gcp->target.len += out_len;
+	if (r)
+		return (r == -EAGAIN) ? 0 : r;
 
 	if (sc->state == GWP_SOCKS5_ST_CMD_CONNECT) {
 		r = socks5_prepare_target_addr(w, gcp);

--- a/src/gwproxy/socks5.c
+++ b/src/gwproxy/socks5.c
@@ -890,6 +890,9 @@ repeat:
 	case GWP_SOCKS5_ST_CMD:
 		r = handle_state_cmd(&arg);
 		break;
+	case GWP_SOCKS5_ST_CMD_CONNECT:
+		r = 0;
+		goto out;
 	default:
 		return -EINVAL;
 	}
@@ -900,6 +903,7 @@ repeat:
 	if (r && r != -EAGAIN && r != -ENOBUFS)
 		conn->state = GWP_SOCKS5_ST_ERR;
 
+out:
 	if (r == -ENOBUFS) {
 		/*
 		 * If we run out of output buffer space, don't change


### PR DESCRIPTION
After stress-testing the SOCKS5 proxy server, I found various memory
corruption bugs. Here is the stress-test program:

  https://gist.github.com/ammarfaizi2/53324bb7dd8ca7cb73a92b80b62f8f3b

Only the first patch is not related to memory corruption bugs.

**1) Fix the wrong batch condition decision.**

If there are 1 entries and 5 workers, and nr_sleeping is 5. It will
always batch because nr_entries + 16 is always greater than 5. That's
just wrong.

**2) Handle `GWP_SOCKS5_ST_CMD_CONNECT` in `gwp_socks5_conn_handle_data()`.**

The `gwp_socks5_conn_handle_data()` does not properly handle socks5
data if the CONNECT command comes together with the proxied data.

**3) Fix missing buf advance and `target.len` increment.**

`gwp_socks5_conn_handle_data()` may return `-EAGAIN` and have `in_len`
or `out_len` greater than zero. Make sure to account those values.

**4) Fix an invalid `handle_socks5_data()` call.**

The call to `handle_socks5_data()` must only be done when the
connection is in `CONN_STATE_SOCKS5_DATA` state.

```
The following changes since commit 19a2f3db2bdba27a98d77b2f1093ce637155e443:

  Merge branch 'dns' (DNS library integration) (2025-07-17 19:21:22 +0700)

are available in the Git repository at:

  https://github.com/ammarfaizi2/gwproxy.git bug-fix

for you to fetch changes up to 33e63762f946a6180696d4aef7d62362840da486:

  gwproxy: Fix an invalid `handle_socks5_data()` call (2025-07-19 12:32:37 +0700)

----------------------------------------------------------------
Ammar Faizi (4):
      gwproxy/dns: Fix the wrong batch condition decision
      gwproxy/socks5: Handle `GWP_SOCKS5_ST_CMD_CONNECT` in `gwp_socks5_conn_handle_data()`
      gwproxy: Fix missing buf advance and `target.len` increment
      gwproxy: Fix an invalid `handle_socks5_data()` call

 src/gwproxy/dns.c     |  2 +-
 src/gwproxy/gwproxy.c | 18 ++++++++++--------
 src/gwproxy/socks5.c  |  4 ++++
 3 files changed, 15 insertions(+), 9 deletions(-)
```