### PR TITLE
gwproxy: SOCKS5 UDP ASSOCIATE support

### DIFF
--- a/README
+++ b/README
@@ -11,7 +11,9 @@ Features
   - SOCKS5 proxy (RFC 1928):
       - CONNECT to IPv4, IPv6 and domain-name (ATYP) targets.
       - UDP ASSOCIATE: relay UDP datagrams to IPv4/IPv6 targets (on both
-        the epoll and io_uring loops).
+        the epoll and io_uring loops). Datagrams to domain-name targets
+        are dropped (no per-datagram DNS yet), and the command is refused
+        when an upstream proxy is configured (UDP is not chained).
       - Username/password authentication (RFC 1929), or no authentication.
   - HTTP proxy:
       - CONNECT tunneling.

--- a/README
+++ b/README
@@ -10,8 +10,8 @@ Features
   - Plain TCP-to-TCP forwarding to a fixed --target.
   - SOCKS5 proxy (RFC 1928):
       - CONNECT to IPv4, IPv6 and domain-name (ATYP) targets.
-      - UDP ASSOCIATE: relay UDP datagrams to IPv4/IPv6 targets (epoll
-        loop only for now).
+      - UDP ASSOCIATE: relay UDP datagrams to IPv4/IPv6 targets (on both
+        the epoll and io_uring loops).
       - Username/password authentication (RFC 1929), or no authentication.
   - HTTP proxy:
       - CONNECT tunneling.

--- a/README
+++ b/README
@@ -8,8 +8,10 @@ termination on the listener (HTTPS proxy).
 Features
 --------
   - Plain TCP-to-TCP forwarding to a fixed --target.
-  - SOCKS5 CONNECT proxy (RFC 1928):
-      - IPv4, IPv6 and domain-name (ATYP) targets.
+  - SOCKS5 proxy (RFC 1928):
+      - CONNECT to IPv4, IPv6 and domain-name (ATYP) targets.
+      - UDP ASSOCIATE: relay UDP datagrams to IPv4/IPv6 targets (epoll
+        loop only for now).
       - Username/password authentication (RFC 1929), or no authentication.
   - HTTP proxy:
       - CONNECT tunneling.

--- a/man/gwproxy.1
+++ b/man/gwproxy.1
@@ -16,8 +16,8 @@ a plain TCP\-to\-TCP forwarder to a fixed
 a
 .B SOCKS5
 proxy (RFC 1928) with CONNECT to IPv4, IPv6 and domain\-name targets, UDP
-ASSOCIATE relaying to IPv4/IPv6 targets (on the epoll loop), and optional
-username/password authentication (RFC 1929);
+ASSOCIATE relaying to IPv4/IPv6 targets, and optional username/password
+authentication (RFC 1929);
 .IP \(bu 3
 an
 .B HTTP

--- a/man/gwproxy.1
+++ b/man/gwproxy.1
@@ -16,7 +16,8 @@ a plain TCP\-to\-TCP forwarder to a fixed
 a
 .B SOCKS5
 proxy (RFC 1928) with CONNECT to IPv4, IPv6 and domain\-name targets, UDP
-ASSOCIATE relaying to IPv4/IPv6 targets, and optional username/password
+ASSOCIATE relaying to IPv4/IPv6 targets (domain\-name targets and upstream\-proxy
+chaining are not supported for UDP), and optional username/password
 authentication (RFC 1929);
 .IP \(bu 3
 an

--- a/man/gwproxy.1
+++ b/man/gwproxy.1
@@ -15,7 +15,8 @@ a plain TCP\-to\-TCP forwarder to a fixed
 .IP \(bu 3
 a
 .B SOCKS5
-proxy (RFC 1928) with IPv4, IPv6 and domain\-name targets and optional
+proxy (RFC 1928) with CONNECT to IPv4, IPv6 and domain\-name targets, UDP
+ASSOCIATE relaying to IPv4/IPv6 targets (on the epoll loop), and optional
 username/password authentication (RFC 1929);
 .IP \(bu 3
 an

--- a/src/gwproxy/ev/epoll.c
+++ b/src/gwproxy/ev/epoll.c
@@ -210,6 +210,15 @@ int gwp_ctx_init_thread_epoll(struct gwp_wrk *w)
 	if (r)
 		goto out_free_events;
 
+	/* Scratch for the SOCKS5 UDP relay; only reachable when as_socks5. */
+	if (ctx->cfg.as_socks5) {
+		w->udp_buf = malloc(GWP_UDP_RELAY_BUFSZ);
+		if (!w->udp_buf) {
+			r = -ENOMEM;
+			goto out_free_events;
+		}
+	}
+
 	pr_dbg(&w->ctx->lh, "Worker %u epoll (ep_fd=%d, ev_fd=%d)", w->idx,
 		ep_fd, ev_fd);
 	return 0;
@@ -244,6 +253,8 @@ void gwp_ctx_free_thread_epoll(struct gwp_wrk *w)
 
 	free(w->events);
 	w->events = NULL;
+	free(w->udp_buf);
+	w->udp_buf = NULL;
 }
 
 static int rearm_accept(struct gwp_wrk *w, int nr_fd_closed)
@@ -307,6 +318,8 @@ static int free_conn_pair(struct gwp_wrk *w, struct gwp_conn_pair *gcp)
 	if (gcp->timer_fd >= 0)
 		nr_fd_closed++;
 	if (gcp->target.fd >= 0)
+		nr_fd_closed++;
+	if (gcp->udp_fd >= 0)
 		nr_fd_closed++;
 
 	r = gwp_free_conn_pair(w, gcp);
@@ -1657,10 +1670,179 @@ static bool is_ev_bit_conn_pair(uint64_t ev_bit)
 	case EV_BIT_CLIENT_SOCKS5:
 	case EV_BIT_DNS_QUERY:
 	case EV_BIT_CLIENT_PROT:
+	case EV_BIT_UDP_RELAY:
 		return true;
 	default:
 		return false;
 	}
+}
+
+static bool sockaddr_eq(const struct gwp_sockaddr *a,
+			const struct gwp_sockaddr *b)
+{
+	if (a->sa.sa_family != b->sa.sa_family)
+		return false;
+	if (a->sa.sa_family == AF_INET)
+		return a->i4.sin_port == b->i4.sin_port &&
+		       a->i4.sin_addr.s_addr == b->i4.sin_addr.s_addr;
+	if (a->sa.sa_family == AF_INET6)
+		return a->i6.sin6_port == b->i6.sin6_port &&
+		       !memcmp(&a->i6.sin6_addr, &b->i6.sin6_addr, 16);
+	return false;
+}
+
+/* Compare only the IP (not the port) of two addresses. */
+static bool sockaddr_ip_eq(const struct gwp_sockaddr *a,
+			   const struct gwp_sockaddr *b)
+{
+	if (a->sa.sa_family != b->sa.sa_family)
+		return false;
+	if (a->sa.sa_family == AF_INET)
+		return a->i4.sin_addr.s_addr == b->i4.sin_addr.s_addr;
+	if (a->sa.sa_family == AF_INET6)
+		return !memcmp(&a->i6.sin6_addr, &b->i6.sin6_addr, 16);
+	return false;
+}
+
+/*
+ * SOCKS5 UDP relay: drain the per-connection relay socket. A datagram whose
+ * source is (or, for the first one, becomes) the pinned client is unwrapped and
+ * forwarded to its encapsulated target; any other source is a target's reply,
+ * which is wrapped with a SOCKS5 UDP header and sent back to the client. UDP is
+ * lossy, so individual datagram errors are dropped rather than failing the
+ * association; only the TCP control connection's close tears it down.
+ *
+ * Known limitations of this first relay, each a follow-up:
+ *   - The relay is stateless: it forwards to any encapsulated target and
+ *     accepts a reply from any non-client source, without tracking which
+ *     targets the client contacted. An off-path host that guesses the
+ *     ephemeral relay port can thus inject a forged "target reply" to the
+ *     client. Pinning validates the client's IP against the TCP control
+ *     connection, so this is bounded to injection (not association hijack);
+ *     restricting replies to previously-contacted targets is the fix.
+ *   - The relay socket's address family is fixed to the control connection's,
+ *     so an IPv4-connected client cannot reach an IPv6 encapsulated target (or
+ *     vice versa); such datagrams are silently dropped.
+ *   - Domain-name (ATYP=0x03) encapsulated targets need DNS in the datagram
+ *     path and are dropped for now.
+ *   - There is no target ACL, so this shares the SSRF exposure of any proxy.
+ */
+static int handle_ev_udp_relay(struct gwp_wrk *w, struct gwp_conn_pair *gcp)
+{
+	const size_t off = GWP_SOCKS5_UDP_HDR_MAX;
+	unsigned char *buf = w->udp_buf;
+	int fd = gcp->udp_fd;
+	int budget = 64;
+
+	/*
+	 * Drain in bounded batches rather than until EAGAIN: a flood on one
+	 * association must not starve the rest of the worker. Any datagrams
+	 * left unread keep the socket readable, so level-triggered epoll
+	 * re-enters this handler on the next wakeup.
+	 */
+	while (budget-- > 0) {
+		struct gwp_sockaddr src;
+		socklen_t srclen = sizeof(src);
+		ssize_t n;
+
+		n = __sys_recvfrom(fd, buf + off, 65535, MSG_NOSIGNAL,
+				   &src.sa, &srclen);
+		if (n < 0) {
+			if (n != -EAGAIN && n != -EINTR)
+				pr_dbg(&w->ctx->lh, "UDP relay recvfrom: %s",
+					strerror((int)-n));
+			return 0;
+		}
+
+		bool client_dgram;
+
+		if (gcp->udp_pinned) {
+			client_dgram = sockaddr_eq(&src, &gcp->udp_peer);
+		} else {
+			/*
+			 * Until the client is pinned nothing can be relayed
+			 * back, so only accept its first datagram, and only
+			 * from the same IP as its TCP control connection (RFC
+			 * 1928); this keeps an off-path source from hijacking
+			 * the association.
+			 */
+			if (!sockaddr_ip_eq(&src, &gcp->client_addr))
+				continue;
+			gcp->udp_peer = src;
+			gcp->udp_pinned = true;
+			client_dgram = true;
+		}
+
+		if (client_dgram) {
+			/* Client -> target: strip the header, forward. */
+			struct gwp_socks5_addr dst;
+			struct gwp_sockaddr tsa;
+			socklen_t tslen;
+			size_t hdr_len;
+
+			if (gwp_socks5_udp_parse_hdr(buf + off, (size_t)n, &dst,
+						     &hdr_len))
+				continue;
+			if (gwp_socks5_addr_to_sockaddr(&dst, &tsa, &tslen))
+				continue;	/* domain target: unsupported */
+			__sys_sendto(fd, buf + off + hdr_len,
+				     (size_t)n - hdr_len, MSG_NOSIGNAL,
+				     &tsa.sa, tslen);
+		} else {
+			/* Target -> client: prepend a header in the front slack. */
+			struct gwp_socks5_addr sa;
+			socklen_t clen;
+			size_t h, hlen;
+
+			if (src.sa.sa_family == AF_INET) {
+				sa.ver = GWP_SOCKS5_ATYP_IPV4;
+				memcpy(sa.ip4, &src.i4.sin_addr, 4);
+				sa.port = src.i4.sin_port;
+				h = 3 + 1 + 4 + 2;
+				clen = sizeof(gcp->udp_peer.i4);
+			} else if (src.sa.sa_family == AF_INET6) {
+				sa.ver = GWP_SOCKS5_ATYP_IPV6;
+				memcpy(sa.ip6, &src.i6.sin6_addr, 16);
+				sa.port = src.i6.sin6_port;
+				h = 3 + 1 + 16 + 2;
+				clen = sizeof(gcp->udp_peer.i6);
+			} else {
+				continue;
+			}
+
+			if (gwp_socks5_udp_build_hdr(&sa, buf + off - h, h, &hlen))
+				continue;
+			__sys_sendto(fd, buf + off - h, h + (size_t)n,
+				     MSG_NOSIGNAL, &gcp->udp_peer.sa, clen);
+		}
+	}
+
+	return 0;
+}
+
+/*
+ * Register the freshly-bound UDP relay socket; its reply is flushed by the
+ * generic prot path.
+ */
+static int handle_udp_associate(struct gwp_wrk *w, struct gwp_conn_pair *gcp)
+{
+	struct epoll_event ev;
+
+	/*
+	 * The association is long-lived, so drop the protocol-handshake timeout
+	 * that was armed for the negotiation; otherwise it would fire and tear
+	 * the relay down mid-session. Closing the timerfd removes it from epoll.
+	 */
+	if (gcp->timer_fd >= 0) {
+		__sys_close(gcp->timer_fd);
+		gcp->timer_fd = -1;
+	}
+
+	ev.events = EPOLLIN;
+	ev.data.u64 = 0;
+	ev.data.ptr = gcp;
+	ev.data.u64 |= EV_BIT_UDP_RELAY;
+	return __sys_epoll_ctl(w->ep_fd, EPOLL_CTL_ADD, gcp->udp_fd, &ev);
 }
 
 static int chk_socks5(struct gwp_wrk *w, struct gwp_conn_pair *gcp, int r)
@@ -1670,6 +1852,9 @@ static int chk_socks5(struct gwp_wrk *w, struct gwp_conn_pair *gcp, int r)
 
 	if (r == 0 && gcp->conn_state == CONN_STATE_SOCKS5_CONNECT)
 		return handle_connect(w, gcp);
+
+	if (r == 0 && gcp->conn_state == CONN_STATE_SOCKS5_UDP_ASSOCIATE)
+		return handle_udp_associate(w, gcp);
 
 	return r;
 }
@@ -1729,6 +1914,16 @@ static int handle_ev_client_prot_in(struct gwp_wrk *w, struct gwp_conn_pair *gcp
 		return 0;
 
 	ct = gcp->conn_state;
+	if (ct == CONN_STATE_SOCKS5_UDP_ASSOCIATE) {
+		/*
+		 * The TCP control connection is idle once the UDP association is
+		 * up (the relay runs on gcp->udp_fd). Discard any stray bytes;
+		 * a peer close was already turned into -ECONNRESET above and
+		 * tears the association down.
+		 */
+		gcp->client.len = 0;
+		return 0;
+	}
 	if (ct == CONN_STATE_PROT) {
 		r = handle_conn_state_prot(w, gcp);
 	} else if (CONN_STATE_HTTP_MIN < ct && ct < CONN_STATE_HTTP_MAX) {
@@ -1986,6 +2181,9 @@ static int handle_event(struct gwp_wrk *w, struct epoll_event *ev)
 		break;
 	case EV_BIT_CLIENT_PROT:
 		r = handle_ev_client_prot(w, udata, ev);
+		break;
+	case EV_BIT_UDP_RELAY:
+		r = handle_ev_udp_relay(w, udata);
 		break;
 	case EV_BIT_TIMER:
 		r = handle_ev_timer(w, udata);

--- a/src/gwproxy/ev/epoll.c
+++ b/src/gwproxy/ev/epoll.c
@@ -1691,19 +1691,6 @@ static bool sockaddr_eq(const struct gwp_sockaddr *a,
 	return false;
 }
 
-/* Compare only the IP (not the port) of two addresses. */
-static bool sockaddr_ip_eq(const struct gwp_sockaddr *a,
-			   const struct gwp_sockaddr *b)
-{
-	if (a->sa.sa_family != b->sa.sa_family)
-		return false;
-	if (a->sa.sa_family == AF_INET)
-		return a->i4.sin_addr.s_addr == b->i4.sin_addr.s_addr;
-	if (a->sa.sa_family == AF_INET6)
-		return !memcmp(&a->i6.sin6_addr, &b->i6.sin6_addr, 16);
-	return false;
-}
-
 /*
  * SOCKS5 UDP relay: drain the per-connection relay socket. A datagram whose
  * source is (or, for the first one, becomes) the pinned client is unwrapped and
@@ -1712,7 +1699,11 @@ static bool sockaddr_ip_eq(const struct gwp_sockaddr *a,
  * lossy, so individual datagram errors are dropped rather than failing the
  * association; only the TCP control connection's close tears it down.
  *
- * Known limitations of this first relay, each a follow-up:
+ * The relay socket is dual-stack, so IPv4 and IPv6 targets both work; an IPv4
+ * target's address is carried v4-mapped internally and unmapped again for the
+ * reply header (see gwp_socks5_addr_to_sockaddr / reply_addr_from_sockaddr).
+ *
+ * Known limitations, each a follow-up:
  *   - The relay is stateless: it forwards to any encapsulated target and
  *     accepts a reply from any non-client source, without tracking which
  *     targets the client contacted. An off-path host that guesses the
@@ -1720,9 +1711,6 @@ static bool sockaddr_ip_eq(const struct gwp_sockaddr *a,
  *     client. Pinning validates the client's IP against the TCP control
  *     connection, so this is bounded to injection (not association hijack);
  *     restricting replies to previously-contacted targets is the fix.
- *   - The relay socket's address family is fixed to the control connection's,
- *     so an IPv4-connected client cannot reach an IPv6 encapsulated target (or
- *     vice versa); such datagrams are silently dropped.
  *   - Domain-name (ATYP=0x03) encapsulated targets need DNS in the datagram
  *     path and are dropped for now.
  *   - There is no target ACL, so this shares the SSRF exposure of any proxy.
@@ -1766,7 +1754,7 @@ static int handle_ev_udp_relay(struct gwp_wrk *w, struct gwp_conn_pair *gcp)
 			 * 1928); this keeps an off-path source from hijacking
 			 * the association.
 			 */
-			if (!sockaddr_ip_eq(&src, &gcp->client_addr))
+			if (!gwp_sockaddr_ip_eq(&src, &gcp->client_addr))
 				continue;
 			gcp->udp_peer = src;
 			gcp->udp_pinned = true;
@@ -1791,29 +1779,17 @@ static int handle_ev_udp_relay(struct gwp_wrk *w, struct gwp_conn_pair *gcp)
 		} else {
 			/* Target -> client: prepend a header in the front slack. */
 			struct gwp_socks5_addr sa;
-			socklen_t clen;
 			size_t h, hlen;
 
-			if (src.sa.sa_family == AF_INET) {
-				sa.ver = GWP_SOCKS5_ATYP_IPV4;
-				memcpy(sa.ip4, &src.i4.sin_addr, 4);
-				sa.port = src.i4.sin_port;
-				h = 3 + 1 + 4 + 2;
-				clen = sizeof(gcp->udp_peer.i4);
-			} else if (src.sa.sa_family == AF_INET6) {
-				sa.ver = GWP_SOCKS5_ATYP_IPV6;
-				memcpy(sa.ip6, &src.i6.sin6_addr, 16);
-				sa.port = src.i6.sin6_port;
-				h = 3 + 1 + 16 + 2;
-				clen = sizeof(gcp->udp_peer.i6);
-			} else {
-				continue;
-			}
-
+			gwp_socks5_reply_addr_from_sockaddr(&src, &sa);
+			h = (sa.ver == GWP_SOCKS5_ATYP_IPV4) ? 3 + 1 + 4 + 2
+							     : 3 + 1 + 16 + 2;
 			if (gwp_socks5_udp_build_hdr(&sa, buf + off - h, h, &hlen))
 				continue;
+			/* The relay is dual-stack, so udp_peer is always AF_INET6. */
 			__sys_sendto(fd, buf + off - h, h + (size_t)n,
-				     MSG_NOSIGNAL, &gcp->udp_peer.sa, clen);
+				     MSG_NOSIGNAL, &gcp->udp_peer.sa,
+				     sizeof(gcp->udp_peer.i6));
 		}
 	}
 

--- a/src/gwproxy/ev/io_uring.c
+++ b/src/gwproxy/ev/io_uring.c
@@ -1644,19 +1644,6 @@ static bool sockaddr_eq(const struct gwp_sockaddr *a,
 	return false;
 }
 
-/* Compare only the IP (not the port) of two addresses. */
-static bool sockaddr_ip_eq(const struct gwp_sockaddr *a,
-			   const struct gwp_sockaddr *b)
-{
-	if (a->sa.sa_family != b->sa.sa_family)
-		return false;
-	if (a->sa.sa_family == AF_INET)
-		return a->i4.sin_addr.s_addr == b->i4.sin_addr.s_addr;
-	if (a->sa.sa_family == AF_INET6)
-		return !memcmp(&a->i6.sin6_addr, &b->i6.sin6_addr, 16);
-	return false;
-}
-
 /* Arm the next relay recvmsg into the front-padded scratch buffer. */
 static void prep_udp_recv(struct gwp_wrk *w, struct gwp_conn_pair *gcp)
 {
@@ -1737,7 +1724,7 @@ static int handle_ev_udp_relay(struct gwp_wrk *w, struct gwp_conn_pair *gcp,
 		 * connection's IP so an off-path source cannot hijack the
 		 * association (RFC 1928).
 		 */
-		if (!sockaddr_ip_eq(&u->src, &gcp->client_addr)) {
+		if (!gwp_sockaddr_ip_eq(&u->src, &gcp->client_addr)) {
 			prep_udp_recv(w, gcp);
 			return 0;
 		}
@@ -1763,32 +1750,18 @@ static int handle_ev_udp_relay(struct gwp_wrk *w, struct gwp_conn_pair *gcp,
 	} else {
 		/* Target -> client: prepend a header in the front slack. */
 		struct gwp_socks5_addr sa;
-		socklen_t clen;
 		size_t h, hlen;
 
-		if (u->src.sa.sa_family == AF_INET) {
-			sa.ver = GWP_SOCKS5_ATYP_IPV4;
-			memcpy(sa.ip4, &u->src.i4.sin_addr, 4);
-			sa.port = u->src.i4.sin_port;
-			h = 3 + 1 + 4 + 2;
-			clen = sizeof(gcp->udp_peer.i4);
-		} else if (u->src.sa.sa_family == AF_INET6) {
-			sa.ver = GWP_SOCKS5_ATYP_IPV6;
-			memcpy(sa.ip6, &u->src.i6.sin6_addr, 16);
-			sa.port = u->src.i6.sin6_port;
-			h = 3 + 1 + 16 + 2;
-			clen = sizeof(gcp->udp_peer.i6);
-		} else {
-			prep_udp_recv(w, gcp);
-			return 0;
-		}
-
+		gwp_socks5_reply_addr_from_sockaddr(&u->src, &sa);
+		h = (sa.ver == GWP_SOCKS5_ATYP_IPV4) ? 3 + 1 + 4 + 2
+						     : 3 + 1 + 16 + 2;
 		if (gwp_socks5_udp_build_hdr(&sa, base - h, h, &hlen)) {
 			prep_udp_recv(w, gcp);
 			return 0;
 		}
+		/* The relay is dual-stack, so udp_peer is always AF_INET6. */
 		prep_udp_send(w, gcp, base - h, h + (size_t)n, &gcp->udp_peer,
-			      clen);
+			      sizeof(gcp->udp_peer.i6));
 	}
 
 	return 0;

--- a/src/gwproxy/ev/io_uring.c
+++ b/src/gwproxy/ev/io_uring.c
@@ -61,6 +61,23 @@ static inline bool client_is_tls(const struct gwp_conn_pair *gcp)
 }
 #endif /* CONFIG_HTTPS */
 
+/*
+ * Per-connection scratch for the io_uring SOCKS5 UDP relay. An async recvmsg /
+ * sendmsg must own a stable buffer and msghdr for the whole operation (epoll
+ * relays synchronously into a per-worker buffer instead), so this is
+ * per-connection. The relay runs serially - at most one recvmsg or sendmsg is
+ * in flight at a time - so a single buffer/msghdr pair suffices. @buf receives
+ * datagrams at offset GWP_SOCKS5_UDP_HDR_MAX so a reply header can be prepended
+ * in place, exactly like the epoll path.
+ */
+struct gwp_iou_udp {
+	struct msghdr		mh;
+	struct iovec		iov;
+	struct gwp_sockaddr	src;	/* recvmsg source of the last datagram */
+	struct gwp_sockaddr	dst;	/* sendmsg destination                 */
+	unsigned char		buf[GWP_UDP_RELAY_BUFSZ];
+};
+
 __cold
 int gwp_ctx_init_thread_io_uring(struct gwp_wrk *w)
 {
@@ -204,7 +221,7 @@ static void get_gcp(struct gwp_conn_pair *gcp)
 static bool put_gcp(struct gwp_wrk *w, struct gwp_conn_pair *gcp)
 {
 	int x = gcp->ref_cnt--;
-	int tg_fd, cl_fd;
+	int tg_fd, cl_fd, ud_fd;
 
 	pr_dbg(&w->ctx->lh,
 		"Put connection pair (idx=%u, cfd=%d, tfd=%d, tmfd=%d, ca=%s, ta=%s, ref_cnt=%d)",
@@ -221,13 +238,22 @@ static bool put_gcp(struct gwp_wrk *w, struct gwp_conn_pair *gcp)
 
 	tg_fd = gcp->target.fd;
 	cl_fd = gcp->client.fd;
+	ud_fd = gcp->udp_fd;
 	gcp->flags |= GWP_CONN_FLAG_NO_CLOSE_FD;
+	/*
+	 * All relay SQEs have drained (ref_cnt hit 0), so the async recvmsg /
+	 * sendmsg no longer touch the scratch or the fd; free/close them here.
+	 */
+	free(gcp->udp_iou);
+	gcp->udp_iou = NULL;
 	gwp_free_conn_pair(w, gcp);
 
 	if (tg_fd >= 0)
 		prep_close(w, tg_fd);
 	if (cl_fd >= 0)
 		prep_close(w, cl_fd);
+	if (ud_fd >= 0)
+		prep_close(w, ud_fd);
 
 	return true;
 }
@@ -435,6 +461,15 @@ static void shutdown_gcp(struct gwp_wrk *w, struct gwp_conn_pair *gcp)
 		io_uring_prep_cancel_fd(s, gcp->client.fd, 0);
 		io_uring_sqe_set_data(s, gcp);
 		s->user_data |= EV_BIT_IOU_CLIENT_CANCEL;
+		get_gcp(gcp);
+	}
+
+	if (gcp->udp_fd >= 0) {
+		pr_dbg(&ctx->lh, "Cancelling UDP relay (fd=%d)", gcp->udp_fd);
+		s = get_sqe_nofail(w);
+		io_uring_prep_cancel_fd(s, gcp->udp_fd, 0);
+		io_uring_sqe_set_data(s, gcp);
+		s->user_data |= EV_BIT_IOU_UDP_CANCEL;
 		get_gcp(gcp);
 	}
 
@@ -1595,6 +1630,214 @@ static int prep_domain_resolution(struct gwp_wrk *w, struct gwp_conn_pair *gcp)
 	return 0;
 }
 
+static bool sockaddr_eq(const struct gwp_sockaddr *a,
+			const struct gwp_sockaddr *b)
+{
+	if (a->sa.sa_family != b->sa.sa_family)
+		return false;
+	if (a->sa.sa_family == AF_INET)
+		return a->i4.sin_port == b->i4.sin_port &&
+		       a->i4.sin_addr.s_addr == b->i4.sin_addr.s_addr;
+	if (a->sa.sa_family == AF_INET6)
+		return a->i6.sin6_port == b->i6.sin6_port &&
+		       !memcmp(&a->i6.sin6_addr, &b->i6.sin6_addr, 16);
+	return false;
+}
+
+/* Compare only the IP (not the port) of two addresses. */
+static bool sockaddr_ip_eq(const struct gwp_sockaddr *a,
+			   const struct gwp_sockaddr *b)
+{
+	if (a->sa.sa_family != b->sa.sa_family)
+		return false;
+	if (a->sa.sa_family == AF_INET)
+		return a->i4.sin_addr.s_addr == b->i4.sin_addr.s_addr;
+	if (a->sa.sa_family == AF_INET6)
+		return !memcmp(&a->i6.sin6_addr, &b->i6.sin6_addr, 16);
+	return false;
+}
+
+/* Arm the next relay recvmsg into the front-padded scratch buffer. */
+static void prep_udp_recv(struct gwp_wrk *w, struct gwp_conn_pair *gcp)
+{
+	struct gwp_iou_udp *u = gcp->udp_iou;
+	struct io_uring_sqe *s = get_sqe_nofail(w);
+
+	u->iov.iov_base = u->buf + GWP_SOCKS5_UDP_HDR_MAX;
+	u->iov.iov_len = 65535;
+	memset(&u->mh, 0, sizeof(u->mh));
+	u->mh.msg_name = &u->src;
+	u->mh.msg_namelen = sizeof(u->src);
+	u->mh.msg_iov = &u->iov;
+	u->mh.msg_iovlen = 1;
+	io_uring_prep_recvmsg(s, gcp->udp_fd, &u->mh, 0);
+	io_uring_sqe_set_data(s, gcp);
+	s->user_data |= EV_BIT_IOU_UDP_RX;
+	get_gcp(gcp);
+}
+
+/* Arm a relay sendmsg of @buf[0..len) to @dst (part of the same scratch). */
+static void prep_udp_send(struct gwp_wrk *w, struct gwp_conn_pair *gcp,
+			  unsigned char *buf, size_t len,
+			  const struct gwp_sockaddr *dst, socklen_t dstlen)
+{
+	struct gwp_iou_udp *u = gcp->udp_iou;
+	struct io_uring_sqe *s = get_sqe_nofail(w);
+
+	u->dst = *dst;
+	u->iov.iov_base = buf;
+	u->iov.iov_len = len;
+	memset(&u->mh, 0, sizeof(u->mh));
+	u->mh.msg_name = &u->dst;
+	u->mh.msg_namelen = dstlen;
+	u->mh.msg_iov = &u->iov;
+	u->mh.msg_iovlen = 1;
+	io_uring_prep_sendmsg(s, gcp->udp_fd, &u->mh, MSG_NOSIGNAL);
+	io_uring_sqe_set_data(s, gcp);
+	s->user_data |= EV_BIT_IOU_UDP_TX;
+	get_gcp(gcp);
+}
+
+/*
+ * A relay recvmsg completed. Decide direction by source (the same logic as the
+ * epoll handle_ev_udp_relay): a datagram from the pinned client is unwrapped
+ * and forwarded to its target; any other source is a target reply, wrapped and
+ * sent to the client. A forwarded datagram issues one sendmsg and the relay
+ * re-arms the recv only once that completes (handle_ev_udp_tx); a dropped
+ * datagram re-arms the recv immediately. See the epoll handler for the design
+ * limitations (stateless replies, same-family targets, no domain targets).
+ */
+static int handle_ev_udp_relay(struct gwp_wrk *w, struct gwp_conn_pair *gcp,
+			       struct io_uring_cqe *cqe)
+{
+	struct gwp_iou_udp *u = gcp->udp_iou;
+	unsigned char *base = u->buf + GWP_SOCKS5_UDP_HDR_MAX;
+	int n = cqe->res;
+	bool client_dgram;
+
+	/*
+	 * Once teardown has begun, let the ref drop instead of re-arming; a
+	 * fresh recv would keep the association alive forever (see the
+	 * udp_fd cancel in shutdown_gcp).
+	 */
+	if (gcp->flags & GWP_CONN_FLAG_IS_CANCEL)
+		return -ECANCELED;
+
+	if (n < 0) {
+		/* Datagram-level error (e.g. a prior send bounced); keep going. */
+		prep_udp_recv(w, gcp);
+		return 0;
+	}
+
+	if (gcp->udp_pinned) {
+		client_dgram = sockaddr_eq(&u->src, &gcp->udp_peer);
+	} else {
+		/*
+		 * Accept the pinning datagram only from the TCP control
+		 * connection's IP so an off-path source cannot hijack the
+		 * association (RFC 1928).
+		 */
+		if (!sockaddr_ip_eq(&u->src, &gcp->client_addr)) {
+			prep_udp_recv(w, gcp);
+			return 0;
+		}
+		gcp->udp_peer = u->src;
+		gcp->udp_pinned = true;
+		client_dgram = true;
+	}
+
+	if (client_dgram) {
+		/* Client -> target: strip the header, forward the payload. */
+		struct gwp_socks5_addr dst;
+		struct gwp_sockaddr tsa;
+		socklen_t tslen;
+		size_t hdr_len;
+
+		if (gwp_socks5_udp_parse_hdr(base, (size_t)n, &dst, &hdr_len) ||
+		    gwp_socks5_addr_to_sockaddr(&dst, &tsa, &tslen)) {
+			prep_udp_recv(w, gcp);	/* bad header or domain target */
+			return 0;
+		}
+		prep_udp_send(w, gcp, base + hdr_len, (size_t)n - hdr_len,
+			      &tsa, tslen);
+	} else {
+		/* Target -> client: prepend a header in the front slack. */
+		struct gwp_socks5_addr sa;
+		socklen_t clen;
+		size_t h, hlen;
+
+		if (u->src.sa.sa_family == AF_INET) {
+			sa.ver = GWP_SOCKS5_ATYP_IPV4;
+			memcpy(sa.ip4, &u->src.i4.sin_addr, 4);
+			sa.port = u->src.i4.sin_port;
+			h = 3 + 1 + 4 + 2;
+			clen = sizeof(gcp->udp_peer.i4);
+		} else if (u->src.sa.sa_family == AF_INET6) {
+			sa.ver = GWP_SOCKS5_ATYP_IPV6;
+			memcpy(sa.ip6, &u->src.i6.sin6_addr, 16);
+			sa.port = u->src.i6.sin6_port;
+			h = 3 + 1 + 16 + 2;
+			clen = sizeof(gcp->udp_peer.i6);
+		} else {
+			prep_udp_recv(w, gcp);
+			return 0;
+		}
+
+		if (gwp_socks5_udp_build_hdr(&sa, base - h, h, &hlen)) {
+			prep_udp_recv(w, gcp);
+			return 0;
+		}
+		prep_udp_send(w, gcp, base - h, h + (size_t)n, &gcp->udp_peer,
+			      clen);
+	}
+
+	return 0;
+}
+
+/* A relay sendmsg completed; read the next datagram (errors are dropped). */
+static int handle_ev_udp_tx(struct gwp_wrk *w, struct gwp_conn_pair *gcp,
+			    struct io_uring_cqe *cqe)
+{
+	(void)cqe;
+	if (gcp->flags & GWP_CONN_FLAG_IS_CANCEL)
+		return -ECANCELED;
+	prep_udp_recv(w, gcp);
+	return 0;
+}
+
+/*
+ * The SOCKS5 UDP ASSOCIATE reply has been queued to the client; bring the relay
+ * online. The TCP control connection is now idle, so drop its handshake timeout
+ * (else it fires and tears the association down) and keep only a recv on it to
+ * notice the client closing. Then start relaying datagrams on udp_fd.
+ */
+static int arm_udp_relay(struct gwp_wrk *w, struct gwp_conn_pair *gcp)
+{
+	int r;
+
+	gcp->udp_iou = calloc(1, sizeof(*gcp->udp_iou));
+	if (unlikely(!gcp->udp_iou))
+		return -ENOMEM;
+
+	r = prep_nr_sqes(w, 3);
+	if (unlikely(r < 0))
+		return r;
+
+	if (w->ctx->cfg.protocol_timeout > 0) {
+		/*
+		 * Mark the pair alive before removing the timer so a timeout
+		 * that fires in the race window is treated as benign by
+		 * handle_ev_timer() (mirrors the TCP connect path).
+		 */
+		gcp->is_target_alive = true;
+		prep_timer_del_target(w, gcp);
+	}
+
+	prep_recv_client_prot(w, gcp);
+	prep_udp_recv(w, gcp);
+	return 0;
+}
+
 /*
  * Act on the result of a protocol handler (SOCKS5 or HTTP), mirroring the epoll
  * chk_socks5()/chk_http(): a pending DNS lookup arms a poll; a fully-decoded
@@ -1612,6 +1855,9 @@ static int chk_prot_result(struct gwp_wrk *w, struct gwp_conn_pair *gcp, int r)
 	if (r == 0 &&
 	    (ct == CONN_STATE_SOCKS5_CONNECT || ct == CONN_STATE_HTTP_CONNECT))
 		return handle_prot_connect_target(w, gcp);
+
+	if (r == 0 && ct == CONN_STATE_SOCKS5_UDP_ASSOCIATE)
+		return arm_udp_relay(w, gcp);
 
 	if (r == 0 || r == -EAGAIN) {
 		/* Handshake incomplete; read more from the client. */
@@ -1655,6 +1901,17 @@ static int handle_ev_client_prot(struct gwp_wrk *w,
 	if (r < 0) {
 		return r;
 	} else if (!r) {
+		prep_recv_client_prot(w, gcp);
+		return 0;
+	}
+
+	/*
+	 * Once the UDP association is up the TCP control connection is idle and
+	 * only watched for close (r < 0, handled above). Discard any stray
+	 * bytes and keep watching.
+	 */
+	if (gcp->conn_state == CONN_STATE_SOCKS5_UDP_ASSOCIATE) {
+		gcp->client.len = 0;
 		prep_recv_client_prot(w, gcp);
 		return 0;
 	}
@@ -1765,6 +2022,20 @@ static int handle_event(struct gwp_wrk *w, struct io_uring_cqe *cqe)
 	case EV_BIT_IOU_CLIENT_PROT:
 		pr_dbg(&ctx->lh, "Handling client protocol event: %d", cqe->res);
 		r = handle_ev_client_prot(w, udata, cqe);
+		break;
+	case EV_BIT_IOU_UDP_RX:
+		pr_dbg(&ctx->lh, "Handling UDP relay recv event: %d", cqe->res);
+		r = handle_ev_udp_relay(w, udata, cqe);
+		break;
+	case EV_BIT_IOU_UDP_TX:
+		pr_dbg(&ctx->lh, "Handling UDP relay send event: %d", cqe->res);
+		r = handle_ev_udp_tx(w, udata, cqe);
+		break;
+	case EV_BIT_IOU_UDP_CANCEL:
+		gcp = udata;
+		pr_dbg(&ctx->lh, "Handling UDP relay cancel event: %d", cqe->res);
+		assert(gcp->flags & GWP_CONN_FLAG_IS_CANCEL);
+		r = 0;
 		break;
 #ifdef CONFIG_HTTPS
 	case EV_BIT_IOU_TLS_DETECT:

--- a/src/gwproxy/gwproxy.c
+++ b/src/gwproxy/gwproxy.c
@@ -745,6 +745,7 @@ static void gwp_ctx_free_thread_sock_pairs(struct gwp_wrk *w)
 			__sys_close(gcp->timer_fd);
 		if (gcp->udp_fd >= 0)
 			__sys_close(gcp->udp_fd);
+		free(gcp->udp_iou);	/* io_uring relay scratch, else NULL */
 
 		/*
 		 * s5_conn and http_conn share a union, so the protocol object
@@ -2188,20 +2189,14 @@ int gwp_handle_conn_state_socks5(struct gwp_wrk *w, struct gwp_conn_pair *gcp)
 		if (!r)
 			gcp->conn_state = CONN_STATE_SOCKS5_CONNECT;
 	} else if (gcp->s5_conn->state == GWP_SOCKS5_ST_CMD_UDP_ASSOCIATE) {
-		if (w->ctx->ev_used == GWP_EV_EPOLL) {
-			r = gwp_socks5_udp_associate_setup(w, gcp);
-			if (!r)
-				gcp->conn_state = CONN_STATE_SOCKS5_UDP_ASSOCIATE;
-		} else {
-			/* The io_uring relay is not implemented yet. */
-			size_t out_len = gcp->target.cap - gcp->target.len;
-
-			gwp_socks5_conn_cmd_udp_associate_res(gcp->s5_conn, NULL,
-				GWP_SOCKS5_REP_COMMAND_NOT_SUPPORTED,
-				gcp->target.buf + gcp->target.len, &out_len);
-			gcp->target.len += (uint32_t)out_len;
-			r = -ENOTSUP;
-		}
+		/*
+		 * Bind the relay socket and queue the reply; both event loops
+		 * then arm their own relay (handle_udp_associate on epoll,
+		 * arm_udp_relay on io_uring).
+		 */
+		r = gwp_socks5_udp_associate_setup(w, gcp);
+		if (!r)
+			gcp->conn_state = CONN_STATE_SOCKS5_UDP_ASSOCIATE;
 	}
 
 	return r;

--- a/src/gwproxy/gwproxy.c
+++ b/src/gwproxy/gwproxy.c
@@ -743,6 +743,8 @@ static void gwp_ctx_free_thread_sock_pairs(struct gwp_wrk *w)
 		free_conn(&gcp->client);
 		if (gcp->timer_fd >= 0)
 			__sys_close(gcp->timer_fd);
+		if (gcp->udp_fd >= 0)
+			__sys_close(gcp->udp_fd);
 
 		/*
 		 * s5_conn and http_conn share a union, so the protocol object
@@ -1425,6 +1427,7 @@ struct gwp_conn_pair *gwp_alloc_conn_pair(struct gwp_wrk *w)
 		goto out_free_target_conn;
 
 	gcp->timer_fd = -1;
+	gcp->udp_fd = -1;
 	gcp->idx = gcs->nr;
 	gcp->conn_state = CONN_STATE_INIT;
 	gcs->pairs[gcs->nr++] = gcp;
@@ -1488,7 +1491,7 @@ int gwp_free_conn_pair(struct gwp_wrk *w, struct gwp_conn_pair *gcp)
 	log_conn_pair_close(w, gcp);
 
 	if (gcp->flags & GWP_CONN_FLAG_NO_CLOSE_FD)
-		gcp->target.fd = gcp->client.fd = gcp->timer_fd = -1;
+		gcp->target.fd = gcp->client.fd = gcp->timer_fd = gcp->udp_fd = -1;
 
 	tmp = gcs->pairs[--gcs->nr];
 	gcs->pairs[gcs->nr] = NULL;
@@ -1500,6 +1503,8 @@ int gwp_free_conn_pair(struct gwp_wrk *w, struct gwp_conn_pair *gcp)
 
 	if (gcp->timer_fd >= 0)
 		__sys_close(gcp->timer_fd);
+	if (gcp->udp_fd >= 0)
+		__sys_close(gcp->udp_fd);
 
 #ifdef CONFIG_NEW_DNS_RESOLVER
 	if (w->ctx->cfg.use_raw_dns && gcp->gdp) {
@@ -2057,6 +2062,106 @@ static int handle_socks5_prot(struct gwp_wrk *w, struct gwp_conn_pair *gcp)
 	return 0;
 }
 
+int gwp_socks5_addr_to_sockaddr(const struct gwp_socks5_addr *a,
+				struct gwp_sockaddr *sa, socklen_t *slen)
+{
+	memset(sa, 0, sizeof(*sa));
+	switch (a->ver) {
+	case GWP_SOCKS5_ATYP_IPV4:
+		sa->i4.sin_family = AF_INET;
+		memcpy(&sa->i4.sin_addr, a->ip4, 4);
+		sa->i4.sin_port = a->port;
+		*slen = sizeof(sa->i4);
+		return 0;
+	case GWP_SOCKS5_ATYP_IPV6:
+		sa->i6.sin6_family = AF_INET6;
+		memcpy(&sa->i6.sin6_addr, a->ip6, 16);
+		sa->i6.sin6_port = a->port;
+		*slen = sizeof(sa->i6);
+		return 0;
+	default:
+		/* Domain targets in relayed datagrams need DNS; not yet. */
+		return -EAFNOSUPPORT;
+	}
+}
+
+int gwp_socks5_udp_associate_setup(struct gwp_wrk *w, struct gwp_conn_pair *gcp)
+{
+	static const int type = SOCK_DGRAM | SOCK_NONBLOCK | SOCK_CLOEXEC;
+	struct gwp_ctx *ctx = w->ctx;
+	struct gwp_socks5_addr bnd;
+	struct gwp_sockaddr local;
+	socklen_t slen = sizeof(local);
+	int fd = -1, r, rep = GWP_SOCKS5_REP_SUCCESS;
+	size_t out_len;
+
+	/*
+	 * Bind the relay on the proxy address the client connected to, so the
+	 * BND.ADDR we return is reachable by the client. getsockname() on the
+	 * accepted TCP fd yields that concrete local address even for a
+	 * wildcard listener.
+	 */
+	r = __sys_getsockname(gcp->client.fd, &local.sa, &slen);
+	if (r < 0) {
+		pr_err(&ctx->lh, "UDP associate: getsockname(client) failed: %s",
+			strerror(-r));
+		rep = GWP_SOCKS5_REP_FAILURE;
+		goto reply;
+	}
+
+	fd = __sys_socket(local.sa.sa_family, type, 0);
+	if (fd < 0) {
+		pr_err(&ctx->lh, "UDP associate: socket() failed: %s", strerror(-fd));
+		rep = GWP_SOCKS5_REP_FAILURE;
+		goto reply;
+	}
+
+	if (ctx->cfg.mark)
+		setskopt_int(fd, SOL_SOCKET, SO_MARK, ctx->cfg.mark);
+
+	/* Ephemeral UDP port on that IP. */
+	if (local.sa.sa_family == AF_INET) {
+		local.i4.sin_port = 0;
+		slen = sizeof(local.i4);
+	} else {
+		local.i6.sin6_port = 0;
+		slen = sizeof(local.i6);
+	}
+
+	r = __sys_bind(fd, &local.sa, slen);
+	if (r < 0) {
+		pr_err(&ctx->lh, "UDP associate: bind() failed: %s", strerror(-r));
+		__sys_close(fd);
+		fd = -1;
+		rep = GWP_SOCKS5_REP_FAILURE;
+		goto reply;
+	}
+
+	r = get_local_addr_for_socks5(ctx, fd, &bnd);
+	if (r < 0) {
+		__sys_close(fd);
+		fd = -1;
+		rep = GWP_SOCKS5_REP_FAILURE;
+		goto reply;
+	}
+
+	gcp->udp_fd = fd;
+	pr_info(&ctx->lh,
+		"SOCKS5 UDP ASSOCIATE relay bound (idx=%u, cfd=%d, ufd=%d)",
+		gcp->idx, gcp->client.fd, fd);
+
+reply:
+	out_len = gcp->target.cap - gcp->target.len;
+	r = gwp_socks5_conn_cmd_udp_associate_res(gcp->s5_conn,
+			(rep == GWP_SOCKS5_REP_SUCCESS) ? &bnd : NULL, rep,
+			gcp->target.buf + gcp->target.len, &out_len);
+	if (r < 0)
+		return r;
+	gcp->target.len += (uint32_t)out_len;
+
+	return (rep == GWP_SOCKS5_REP_SUCCESS) ? 0 : -ECONNREFUSED;
+}
+
 int gwp_handle_conn_state_socks5(struct gwp_wrk *w, struct gwp_conn_pair *gcp)
 {
 	int r, ct;
@@ -2082,6 +2187,21 @@ int gwp_handle_conn_state_socks5(struct gwp_wrk *w, struct gwp_conn_pair *gcp)
 
 		if (!r)
 			gcp->conn_state = CONN_STATE_SOCKS5_CONNECT;
+	} else if (gcp->s5_conn->state == GWP_SOCKS5_ST_CMD_UDP_ASSOCIATE) {
+		if (w->ctx->ev_used == GWP_EV_EPOLL) {
+			r = gwp_socks5_udp_associate_setup(w, gcp);
+			if (!r)
+				gcp->conn_state = CONN_STATE_SOCKS5_UDP_ASSOCIATE;
+		} else {
+			/* The io_uring relay is not implemented yet. */
+			size_t out_len = gcp->target.cap - gcp->target.len;
+
+			gwp_socks5_conn_cmd_udp_associate_res(gcp->s5_conn, NULL,
+				GWP_SOCKS5_REP_COMMAND_NOT_SUPPORTED,
+				gcp->target.buf + gcp->target.len, &out_len);
+			gcp->target.len += (uint32_t)out_len;
+			r = -ENOTSUP;
+		}
 	}
 
 	return r;

--- a/src/gwproxy/gwproxy.c
+++ b/src/gwproxy/gwproxy.c
@@ -1722,12 +1722,12 @@ static int get_local_addr_for_socks5(struct gwp_ctx *ctx, int fd,
 	case AF_INET:
 		ba->ver = GWP_SOCKS5_ATYP_IPV4;
 		memcpy(&ba->ip4, &t.i4.sin_addr, 4);
-		ba->port = ntohs(t.i4.sin_port);
+		ba->port = t.i4.sin_port;
 		return 0;
 	case AF_INET6:
 		ba->ver = GWP_SOCKS5_ATYP_IPV6;
 		memcpy(&ba->ip6, &t.i6.sin6_addr, 16);
-		ba->port = ntohs(t.i6.sin6_port);
+		ba->port = t.i6.sin6_port;
 		return 0;
 	default:
 		pr_err(&ctx->lh, "Unsupported address family %d for local socket",

--- a/src/gwproxy/gwproxy.c
+++ b/src/gwproxy/gwproxy.c
@@ -2172,6 +2172,17 @@ int gwp_socks5_udp_associate_setup(struct gwp_wrk *w, struct gwp_conn_pair *gcp)
 	size_t out_len;
 
 	/*
+	 * UDP ASSOCIATE is not chained through an upstream proxy: an HTTP
+	 * upstream cannot carry UDP at all, and SOCKS5 upstream UDP is not
+	 * implemented. Binding a local relay here would silently bypass the
+	 * configured chain, so refuse the command instead.
+	 */
+	if (ctx->upstream.enabled) {
+		rep = GWP_SOCKS5_REP_COMMAND_NOT_SUPPORTED;
+		goto reply;
+	}
+
+	/*
 	 * The relay is a dual-stack IPv6 socket bound to the wildcard address so
 	 * one socket can both receive from the client and reach IPv4 and IPv6
 	 * targets (a socket bound to a single-family local address cannot egress

--- a/src/gwproxy/gwproxy.c
+++ b/src/gwproxy/gwproxy.c
@@ -2063,16 +2063,66 @@ static int handle_socks5_prot(struct gwp_wrk *w, struct gwp_conn_pair *gcp)
 	return 0;
 }
 
+/* Write the IPv4-mapped IPv6 form (::ffff:a.b.c.d) of a 4-byte address. */
+static void set_v4mapped(struct in6_addr *a6, const void *v4)
+{
+	memset(a6, 0, sizeof(*a6));
+	a6->s6_addr[10] = 0xff;
+	a6->s6_addr[11] = 0xff;
+	memcpy(&a6->s6_addr[12], v4, 4);
+}
+
+/* Canonicalise an address to (is_v4, pointer to its 4- or 16-byte IP). */
+static void sockaddr_canon_ip(const struct gwp_sockaddr *a, bool *is_v4,
+			      const uint8_t **ip)
+{
+	if (a->sa.sa_family == AF_INET) {
+		*is_v4 = true;
+		*ip = (const uint8_t *)&a->i4.sin_addr;
+		return;
+	}
+	if (IN6_IS_ADDR_V4MAPPED(&a->i6.sin6_addr)) {
+		*is_v4 = true;
+		*ip = &a->i6.sin6_addr.s6_addr[12];
+		return;
+	}
+	*is_v4 = false;
+	*ip = a->i6.sin6_addr.s6_addr;
+}
+
+/*
+ * Compare two addresses by IP only (not port), treating an IPv4 address and its
+ * IPv4-mapped IPv6 form as equal. The UDP relay socket is dual-stack, so a
+ * datagram's source is always AF_INET6 (v4-mapped for an IPv4 peer) while the
+ * pinned client address may be either family; this bridges them.
+ */
+bool gwp_sockaddr_ip_eq(const struct gwp_sockaddr *a, const struct gwp_sockaddr *b)
+{
+	const uint8_t *ai, *bi;
+	bool av4, bv4;
+
+	sockaddr_canon_ip(a, &av4, &ai);
+	sockaddr_canon_ip(b, &bv4, &bi);
+	if (av4 != bv4)
+		return false;
+	return !memcmp(ai, bi, av4 ? 4 : 16);
+}
+
 int gwp_socks5_addr_to_sockaddr(const struct gwp_socks5_addr *a,
 				struct gwp_sockaddr *sa, socklen_t *slen)
 {
+	/*
+	 * The relay socket is dual-stack AF_INET6, so every target is expressed
+	 * as an IPv6 sockaddr: an IPv4 target becomes its IPv4-mapped form so
+	 * one socket can reach both families.
+	 */
 	memset(sa, 0, sizeof(*sa));
 	switch (a->ver) {
 	case GWP_SOCKS5_ATYP_IPV4:
-		sa->i4.sin_family = AF_INET;
-		memcpy(&sa->i4.sin_addr, a->ip4, 4);
-		sa->i4.sin_port = a->port;
-		*slen = sizeof(sa->i4);
+		sa->i6.sin6_family = AF_INET6;
+		set_v4mapped(&sa->i6.sin6_addr, a->ip4);
+		sa->i6.sin6_port = a->port;
+		*slen = sizeof(sa->i6);
 		return 0;
 	case GWP_SOCKS5_ATYP_IPV6:
 		sa->i6.sin6_family = AF_INET6;
@@ -2086,21 +2136,50 @@ int gwp_socks5_addr_to_sockaddr(const struct gwp_socks5_addr *a,
 	}
 }
 
+/*
+ * Fill a SOCKS5 header address from a UDP reply's source. The relay is
+ * dual-stack so the source is AF_INET6; a v4-mapped source is unmapped back to
+ * an IPv4 ATYP so the client sees the target it actually addressed.
+ */
+void gwp_socks5_reply_addr_from_sockaddr(const struct gwp_sockaddr *src,
+					 struct gwp_socks5_addr *a)
+{
+	if (src->sa.sa_family == AF_INET) {
+		a->ver = GWP_SOCKS5_ATYP_IPV4;
+		memcpy(a->ip4, &src->i4.sin_addr, 4);
+		a->port = src->i4.sin_port;
+		return;
+	}
+	if (IN6_IS_ADDR_V4MAPPED(&src->i6.sin6_addr)) {
+		a->ver = GWP_SOCKS5_ATYP_IPV4;
+		memcpy(a->ip4, &src->i6.sin6_addr.s6_addr[12], 4);
+		a->port = src->i6.sin6_port;
+		return;
+	}
+	a->ver = GWP_SOCKS5_ATYP_IPV6;
+	memcpy(a->ip6, &src->i6.sin6_addr, 16);
+	a->port = src->i6.sin6_port;
+}
+
 int gwp_socks5_udp_associate_setup(struct gwp_wrk *w, struct gwp_conn_pair *gcp)
 {
 	static const int type = SOCK_DGRAM | SOCK_NONBLOCK | SOCK_CLOEXEC;
 	struct gwp_ctx *ctx = w->ctx;
 	struct gwp_socks5_addr bnd;
-	struct gwp_sockaddr local;
+	struct gwp_sockaddr local, relay;
 	socklen_t slen = sizeof(local);
 	int fd = -1, r, rep = GWP_SOCKS5_REP_SUCCESS;
 	size_t out_len;
 
 	/*
-	 * Bind the relay on the proxy address the client connected to, so the
-	 * BND.ADDR we return is reachable by the client. getsockname() on the
-	 * accepted TCP fd yields that concrete local address even for a
-	 * wildcard listener.
+	 * The relay is a dual-stack IPv6 socket bound to the wildcard address so
+	 * one socket can both receive from the client and reach IPv4 and IPv6
+	 * targets (a socket bound to a single-family local address cannot egress
+	 * the other family). BND.ADDR must still be an address the client can
+	 * reach, so it is taken from the proxy address the client connected to
+	 * (getsockname() on the control fd), paired with the relay's ephemeral
+	 * port. Widening the bind to the wildcard does not change the threat
+	 * model: the port is ephemeral and the client is IP-pinned.
 	 */
 	r = __sys_getsockname(gcp->client.fd, &local.sa, &slen);
 	if (r < 0) {
@@ -2110,26 +2189,22 @@ int gwp_socks5_udp_associate_setup(struct gwp_wrk *w, struct gwp_conn_pair *gcp)
 		goto reply;
 	}
 
-	fd = __sys_socket(local.sa.sa_family, type, 0);
+	fd = __sys_socket(AF_INET6, type, 0);
 	if (fd < 0) {
 		pr_err(&ctx->lh, "UDP associate: socket() failed: %s", strerror(-fd));
 		rep = GWP_SOCKS5_REP_FAILURE;
 		goto reply;
 	}
 
+	setskopt_int(fd, IPPROTO_IPV6, IPV6_V6ONLY, 0);
 	if (ctx->cfg.mark)
 		setskopt_int(fd, SOL_SOCKET, SO_MARK, ctx->cfg.mark);
 
-	/* Ephemeral UDP port on that IP. */
-	if (local.sa.sa_family == AF_INET) {
-		local.i4.sin_port = 0;
-		slen = sizeof(local.i4);
-	} else {
-		local.i6.sin6_port = 0;
-		slen = sizeof(local.i6);
-	}
-
-	r = __sys_bind(fd, &local.sa, slen);
+	memset(&relay, 0, sizeof(relay));
+	relay.i6.sin6_family = AF_INET6;
+	relay.i6.sin6_addr = in6addr_any;
+	relay.i6.sin6_port = 0;
+	r = __sys_bind(fd, &relay.sa, sizeof(relay.i6));
 	if (r < 0) {
 		pr_err(&ctx->lh, "UDP associate: bind() failed: %s", strerror(-r));
 		__sys_close(fd);
@@ -2138,13 +2213,25 @@ int gwp_socks5_udp_associate_setup(struct gwp_wrk *w, struct gwp_conn_pair *gcp)
 		goto reply;
 	}
 
-	r = get_local_addr_for_socks5(ctx, fd, &bnd);
+	/* BND.ADDR from the control connection, BND.PORT from the relay socket. */
+	slen = sizeof(relay);
+	r = __sys_getsockname(fd, &relay.sa, &slen);
 	if (r < 0) {
+		pr_err(&ctx->lh, "UDP associate: getsockname(relay) failed: %s",
+			strerror(-r));
 		__sys_close(fd);
 		fd = -1;
 		rep = GWP_SOCKS5_REP_FAILURE;
 		goto reply;
 	}
+	if (local.sa.sa_family == AF_INET) {
+		bnd.ver = GWP_SOCKS5_ATYP_IPV4;
+		memcpy(bnd.ip4, &local.i4.sin_addr, 4);
+	} else {
+		bnd.ver = GWP_SOCKS5_ATYP_IPV6;
+		memcpy(bnd.ip6, &local.i6.sin6_addr, 16);
+	}
+	bnd.port = relay.i6.sin6_port;
 
 	gcp->udp_fd = fd;
 	pr_info(&ctx->lh,

--- a/src/gwproxy/gwproxy.h
+++ b/src/gwproxy/gwproxy.h
@@ -451,9 +451,20 @@ void gwp_setup_cli_sock_options(struct gwp_wrk *w, int fd);
  */
 int gwp_socks5_udp_associate_setup(struct gwp_wrk *w, struct gwp_conn_pair *gcp);
 
-/* Convert a SOCKS5 IPv4/IPv6 address to a sockaddr (domain -> -EAFNOSUPPORT). */
+/*
+ * Convert a SOCKS5 IPv4/IPv6 target to a sockaddr for the dual-stack UDP relay
+ * (always AF_INET6; IPv4 is returned v4-mapped). Domain -> -EAFNOSUPPORT.
+ */
 int gwp_socks5_addr_to_sockaddr(const struct gwp_socks5_addr *a,
 				struct gwp_sockaddr *sa, socklen_t *slen);
+
+/* Fill a SOCKS5 UDP reply-header address from a datagram source (unmaps v4). */
+void gwp_socks5_reply_addr_from_sockaddr(const struct gwp_sockaddr *src,
+					 struct gwp_socks5_addr *a);
+
+/* Compare two addresses by IP only, matching IPv4 with its v4-mapped form. */
+bool gwp_sockaddr_ip_eq(const struct gwp_sockaddr *a,
+			const struct gwp_sockaddr *b);
 int gwp_get_orig_dst(int fd, const struct gwp_sockaddr *client,
 		     struct gwp_sockaddr *dst);
 const char *ip_to_str(const struct gwp_sockaddr *gs);

--- a/src/gwproxy/gwproxy.h
+++ b/src/gwproxy/gwproxy.h
@@ -111,6 +111,12 @@ enum {
 	EV_BIT_RAW_DNS_QUERY		= (19ull << 48ull),
 
 	/*
+	 * Per-connection UDP relay socket for a SOCKS5 UDP ASSOCIATE. Values
+	 * 9-21 are reserved by the io_uring aliases below, so use 22.
+	 */
+	EV_BIT_UDP_RELAY		= (22ull << 48ull),
+
+	/*
 	 * This ev_bit is used for user_data masking during protocol
 	 * initalization.
 	 *
@@ -162,6 +168,7 @@ enum {
 	CONN_STATE_SOCKS5_MIN		= 100,
 	CONN_STATE_SOCKS5_DATA		= 101,
 	CONN_STATE_SOCKS5_CONNECT	= 102,
+	CONN_STATE_SOCKS5_UDP_ASSOCIATE	= 103,	/* relay active; TCP conn idle */
 	CONN_STATE_SOCKS5_DNS_QUERY	= 104,
 	CONN_STATE_SOCKS5_MAX		= 199,
 
@@ -277,6 +284,19 @@ struct gwp_conn_pair {
 	uint64_t		flags;
 	int			conn_state;
 	int			timer_fd;
+
+	/*
+	 * SOCKS5 UDP ASSOCIATE relay. @udp_fd is the per-connection bound UDP
+	 * socket the client sends datagrams to (-1 when not a UDP association);
+	 * its lifetime is tied to this (TCP control) connection. @udp_peer is
+	 * the client's UDP source address, pinned from its first datagram
+	 * (@udp_pinned); datagrams from other sources are treated as replies
+	 * from targets.
+	 */
+	int			udp_fd;
+	bool			udp_pinned;
+	struct gwp_sockaddr	udp_peer;
+
 	uint32_t		idx;
 	union {
 		struct gwp_socks5_conn	*s5_conn;
@@ -359,6 +379,14 @@ struct gwp_wrk {
 	uint32_t		idx;
 	pthread_t		thread;
 
+	/*
+	 * Per-worker scratch for the SOCKS5 UDP relay, allocated at worker
+	 * start when SOCKS5 is enabled. A datagram is received at offset
+	 * GWP_SOCKS5_UDP_HDR_MAX so a reply header can be prepended in-place
+	 * (no copy); the tail holds up to one max-size UDP payload.
+	 */
+	unsigned char		*udp_buf;
+
 #ifdef CONFIG_NEW_DNS_RESOLVER
 	struct gwp_wrk_dns	*dns;
 #endif
@@ -393,6 +421,26 @@ int gwp_create_sock_target(struct gwp_wrk *w, struct gwp_sockaddr *addr,
 			   bool *is_target_alive, bool non_block);
 int gwp_create_timer(int fd, int sec, int nsec);
 void gwp_setup_cli_sock_options(struct gwp_wrk *w, int fd);
+
+/*
+ * Per-worker SOCKS5 UDP relay scratch: room to prepend a max relay header plus
+ * one max-size UDP payload (65535 bytes). Datagrams are received at offset
+ * GWP_SOCKS5_UDP_HDR_MAX within it.
+ */
+#define GWP_UDP_RELAY_BUFSZ	(GWP_SOCKS5_UDP_HDR_MAX + 65535)
+
+/*
+ * Create and bind the per-connection UDP relay socket for a SOCKS5 UDP
+ * ASSOCIATE, derive its BND.ADDR:PORT and write the SOCKS5 reply into
+ * gcp->target.buf (for the caller to flush to the client), and stash the fd in
+ * gcp->udp_fd. On failure a SOCKS5 failure reply is queued instead and a
+ * negative error is returned. The caller registers the fd with its event loop.
+ */
+int gwp_socks5_udp_associate_setup(struct gwp_wrk *w, struct gwp_conn_pair *gcp);
+
+/* Convert a SOCKS5 IPv4/IPv6 address to a sockaddr (domain -> -EAFNOSUPPORT). */
+int gwp_socks5_addr_to_sockaddr(const struct gwp_socks5_addr *a,
+				struct gwp_sockaddr *sa, socklen_t *slen);
 int gwp_get_orig_dst(int fd, const struct gwp_sockaddr *client,
 		     struct gwp_sockaddr *dst);
 const char *ip_to_str(const struct gwp_sockaddr *gs);

--- a/src/gwproxy/gwproxy.h
+++ b/src/gwproxy/gwproxy.h
@@ -34,6 +34,7 @@
 struct gwp_ssl_ctx;
 struct gwp_ssl;
 struct gwp_iou_tls;
+struct gwp_iou_udp;
 
 struct gwp_cfg {
 	const char	*event_loop;
@@ -153,6 +154,15 @@ enum {
 	EV_BIT_IOU_TLS_HS_SEND		= (19ull << 48ull),
 	EV_BIT_IOU_UPSTREAM_S5		= (20ull << 48ull),
 	EV_BIT_IOU_ACCEPT_RETRY		= (21ull << 48ull),
+
+	/*
+	 * SOCKS5 UDP relay on io_uring. The recvmsg reuses the shared
+	 * EV_BIT_UDP_RELAY (22); the sendmsg and the fd-cancel need their own
+	 * selectors so the completion dispatch can tell them apart.
+	 */
+	EV_BIT_IOU_UDP_RX		= EV_BIT_UDP_RELAY,
+	EV_BIT_IOU_UDP_TX		= (23ull << 48ull),
+	EV_BIT_IOU_UDP_CANCEL		= (24ull << 48ull),
 #endif
 };
 
@@ -291,11 +301,14 @@ struct gwp_conn_pair {
 	 * its lifetime is tied to this (TCP control) connection. @udp_peer is
 	 * the client's UDP source address, pinned from its first datagram
 	 * (@udp_pinned); datagrams from other sources are treated as replies
-	 * from targets.
+	 * from targets. @udp_iou is the io_uring relay's per-connection async
+	 * scratch (msghdr + buffer), NULL on the epoll loop which relays
+	 * synchronously into the per-worker udp_buf.
 	 */
 	int			udp_fd;
 	bool			udp_pinned;
 	struct gwp_sockaddr	udp_peer;
+	struct gwp_iou_udp	*udp_iou;
 
 	uint32_t		idx;
 	union {

--- a/src/gwproxy/socks5.c
+++ b/src/gwproxy/socks5.c
@@ -515,6 +515,7 @@ static int set_err_reply(struct data_arg *d, uint8_t err_code)
  *      the authentication method in use.
  */
 static int handle_cmd_connect(struct data_arg *d);
+static int handle_cmd_udp_associate(struct data_arg *d);
 static int handle_state_cmd(struct data_arg *d)
 {
 	size_t len = *d->in_len, exp_len;
@@ -537,14 +538,14 @@ static int handle_state_cmd(struct data_arg *d)
 	switch (buf[1]) {
 	case 0x01: /* CONNECT */
 		return handle_cmd_connect(d);
+	case 0x03: /* UDP ASSOCIATE */
+		return handle_cmd_udp_associate(d);
 
 	/*
 	 * TODO(ammarfaizi2):
-	 * Implement BIND and UDP ASSOCIATE commands. For now,
-	 * we just return an error.
+	 * Implement the BIND command. For now, we just return an error.
 	 */
 	case 0x02: /* BIND */
-	case 0x03: /* UDP ASSOCIATE */
 	default:
 		/*
 		 * 0x07 = Command not supported.
@@ -553,10 +554,14 @@ static int handle_state_cmd(struct data_arg *d)
 	}
 }
 
-static int handle_cmd_connect(struct data_arg *d)
+/*
+ * Parse the ATYP + ADDR + PORT tail shared by the CONNECT and UDP ASSOCIATE
+ * requests into @da, advancing the input buffer past it. @buf points at the
+ * ATYP byte's request (index 3). Returns 0, -EAGAIN if incomplete, or a
+ * set_err_reply() result for an unsupported ATYP.
+ */
+static int parse_request_addr(struct data_arg *d, struct gwp_socks5_addr *da)
 {
-	struct gwp_socks5_addr *da = &d->conn->dst_addr;
-	struct gwp_socks5_conn *conn = d->conn;
 	size_t len = *d->in_len, exp_len;
 	const uint8_t *buf = d->in_buf;
 	uint8_t atyp, domlen = 0;
@@ -565,21 +570,12 @@ static int handle_cmd_connect(struct data_arg *d)
 	atyp = buf[3];
 	switch (atyp) {
 	case GWP_SOCKS5_ATYP_IPV4:
-		/*
-		 * IPv4 address and port.
-		 */
 		exp_len += 4 + 2;
 		break;
 	case GWP_SOCKS5_ATYP_IPV6:
-		/*
-		 * IPv6 address and port.
-		 */
 		exp_len += 16 + 2;
 		break;
 	case GWP_SOCKS5_ATYP_DOMAIN:
-		/*
-		 * Domain name and port.
-		 */
 		exp_len += 1; /* Length of domain name */
 		if (len < exp_len)
 			return -EAGAIN;
@@ -593,7 +589,6 @@ static int handle_cmd_connect(struct data_arg *d)
 	if (len < exp_len)
 		return -EAGAIN;
 
-	/* Copy the address and port into the connection structure. */
 	switch (atyp) {
 	case GWP_SOCKS5_ATYP_IPV4:
 		da->ver = GWP_SOCKS5_ATYP_IPV4;
@@ -614,8 +609,35 @@ static int handle_cmd_connect(struct data_arg *d)
 		break;
 	}
 
-	conn->state = GWP_SOCKS5_ST_CMD_CONNECT;
 	advance_in_buf(d, exp_len);
+	return 0;
+}
+
+static int handle_cmd_connect(struct data_arg *d)
+{
+	int r = parse_request_addr(d, &d->conn->dst_addr);
+
+	if (r)
+		return r;
+
+	d->conn->state = GWP_SOCKS5_ST_CMD_CONNECT;
+	return 0;
+}
+
+/*
+ * UDP ASSOCIATE: the DST.ADDR/DST.PORT names the address the client will send
+ * datagrams from (often 0.0.0.0:0, "not yet known"). Keep it in dst_addr; the
+ * relay uses it to pin the client, or pins from the first datagram. The proxy
+ * opens the relay socket and answers with its endpoint from the event loop.
+ */
+static int handle_cmd_udp_associate(struct data_arg *d)
+{
+	int r = parse_request_addr(d, &d->conn->dst_addr);
+
+	if (r)
+		return r;
+
+	d->conn->state = GWP_SOCKS5_ST_CMD_UDP_ASSOCIATE;
 	return 0;
 }
 
@@ -647,6 +669,7 @@ repeat:
 		r = handle_state_cmd(&arg);
 		break;
 	case GWP_SOCKS5_ST_CMD_CONNECT:
+	case GWP_SOCKS5_ST_CMD_UDP_ASSOCIATE:
 		r = 0;
 		goto out;
 	default:
@@ -698,7 +721,8 @@ static int __gwp_socks5_conn_cmd_connect_res(struct data_arg *arg,
 	size_t resp_len = 0;
 	uint8_t resp[1024];
 
-	if (arg->conn->state != GWP_SOCKS5_ST_CMD_CONNECT)
+	if (arg->conn->state != GWP_SOCKS5_ST_CMD_CONNECT &&
+	    arg->conn->state != GWP_SOCKS5_ST_CMD_UDP_ASSOCIATE)
 		return -EINVAL;
 
 	resp[0] = 0x05; /* VER */
@@ -742,6 +766,31 @@ int gwp_socks5_conn_cmd_connect_res(struct gwp_socks5_conn *conn,
 
 	if (r != -ENOBUFS)
 		conn->state = (rep == 0x00) ? GWP_SOCKS5_ST_FORWARDING
+					    : GWP_SOCKS5_ST_ERR;
+
+	return r;
+}
+
+int gwp_socks5_conn_cmd_udp_associate_res(struct gwp_socks5_conn *conn,
+					  const struct gwp_socks5_addr *bind_addr,
+					  uint8_t rep, void *out_buf,
+					  size_t *out_len)
+{
+	struct data_arg arg = {
+		.ctx = conn->ctx,
+		.conn = conn,
+		.in_buf = NULL,
+		.in_len = NULL,
+		.out_buf = out_buf,
+		.out_len = out_len,
+		.tot_out_len = 0,
+		.tot_advance = 0
+	};
+	int r = __gwp_socks5_conn_cmd_connect_res(&arg, bind_addr, rep);
+	*out_len = arg.tot_out_len;
+
+	if (r != -ENOBUFS)
+		conn->state = (rep == 0x00) ? GWP_SOCKS5_ST_UDP_ASSOCIATED
 					    : GWP_SOCKS5_ST_ERR;
 
 	return r;
@@ -927,5 +976,82 @@ int gwp_socks5_cli_parse_connect(const void *buf, size_t len,
 
 	*rep = b[1];
 	*consumed = need;
+	return 0;
+}
+
+int gwp_socks5_udp_parse_hdr(const void *buf, size_t len,
+			     struct gwp_socks5_addr *addr, size_t *hdr_len)
+{
+	const uint8_t *b = buf;
+	uint8_t atyp;
+	size_t need;
+
+	/* RSV(2) + FRAG(1) + ATYP(1). */
+	if (len < 4)
+		return -EAGAIN;
+	if (b[2] != 0x00)
+		return -ENOTSUP;	/* we do not reassemble fragments */
+
+	atyp = b[3];
+	switch (atyp) {
+	case GWP_SOCKS5_ATYP_IPV4:
+		need = 4 + 4 + 2;
+		if (len < need)
+			return -EAGAIN;
+		addr->ver = GWP_SOCKS5_ATYP_IPV4;
+		memcpy(addr->ip4, &b[4], 4);
+		memcpy(&addr->port, &b[8], 2);
+		break;
+	case GWP_SOCKS5_ATYP_IPV6:
+		need = 4 + 16 + 2;
+		if (len < need)
+			return -EAGAIN;
+		addr->ver = GWP_SOCKS5_ATYP_IPV6;
+		memcpy(addr->ip6, &b[4], 16);
+		memcpy(&addr->port, &b[20], 2);
+		break;
+	case GWP_SOCKS5_ATYP_DOMAIN: {
+		uint8_t domlen;
+
+		if (len < 5)
+			return -EAGAIN;
+		domlen = b[4];
+		need = 4 + 1 + domlen + 2;
+		if (len < need)
+			return -EAGAIN;
+		addr->ver = GWP_SOCKS5_ATYP_DOMAIN;
+		addr->domain.len = domlen;
+		memcpy(addr->domain.str, &b[5], domlen);
+		addr->domain.str[domlen] = '\0';
+		memcpy(&addr->port, &b[5 + domlen], 2);
+		break;
+	}
+	default:
+		return -EINVAL;
+	}
+
+	*hdr_len = need;
+	return 0;
+}
+
+int gwp_socks5_udp_build_hdr(const struct gwp_socks5_addr *addr, void *buf,
+			     size_t cap, size_t *hdr_len)
+{
+	uint8_t *b = buf;
+	int al = gwp_socks5_addr_len(addr);
+	size_t total;
+
+	if (al < 0)
+		return -EINVAL;
+
+	total = 3 + (size_t)al;	/* RSV(2) + FRAG(1) + ATYP + addr + port */
+	if (cap < total)
+		return -ENOBUFS;
+
+	b[0] = 0x00;	/* RSV */
+	b[1] = 0x00;
+	b[2] = 0x00;	/* FRAG */
+	gwp_socks5_addr_encode(&b[3], addr);
+	*hdr_len = total;
 	return 0;
 }

--- a/src/gwproxy/socks5.h
+++ b/src/gwproxy/socks5.h
@@ -17,10 +17,18 @@ enum gwp_socks5_state {
 	GWP_SOCKS5_ST_INIT		= 0,
 	GWP_SOCKS5_ST_CMD		= 100,
 	GWP_SOCKS5_ST_CMD_CONNECT	= 101,
+	GWP_SOCKS5_ST_CMD_UDP_ASSOCIATE	= 102,
 	GWP_SOCKS5_ST_AUTH_USERPASS	= 200,
 	GWP_SOCKS5_ST_FORWARDING	= 300,
+	GWP_SOCKS5_ST_UDP_ASSOCIATED	= 400,
 	GWP_SOCKS5_ST_ERR		= 500,
 };
+
+/*
+ * Largest SOCKS5 UDP relay header (RFC 1928 section 7):
+ * RSV(2) + FRAG(1) + ATYP(1) + ADDR(1 len + 255 domain) + PORT(2).
+ */
+#define GWP_SOCKS5_UDP_HDR_MAX	(2 + 1 + 1 + 1 + 255 + 2)
 
 enum gwp_socks5_atyp {
 	GWP_SOCKS5_ATYP_IPV4		= 0x01,
@@ -178,6 +186,48 @@ int gwp_socks5_conn_cmd_connect_res(struct gwp_socks5_conn *conn,
 				    const struct gwp_socks5_addr *bind_addr,
 				    uint8_t rep, void *out_buf,
 				    size_t *out_len);
+
+/**
+ * Construct the reply to a SOCKS5 UDP ASSOCIATE command. @bind_addr is the
+ * proxy's UDP relay endpoint (from getsockname() on the relay socket) that the
+ * client will send its datagrams to. On a success reply (rep == 0x00) the
+ * connection state becomes GWP_SOCKS5_ST_UDP_ASSOCIATED; otherwise
+ * GWP_SOCKS5_ST_ERR. Same buffer semantics and errors as
+ * gwp_socks5_conn_cmd_connect_res().
+ */
+int gwp_socks5_conn_cmd_udp_associate_res(struct gwp_socks5_conn *conn,
+					  const struct gwp_socks5_addr *bind_addr,
+					  uint8_t rep, void *out_buf,
+					  size_t *out_len);
+
+/*
+ * SOCKS5 UDP relay datagram header codec (RFC 1928 section 7). Stateless.
+ *
+ *   +----+------+------+----------+----------+----------+
+ *   |RSV | FRAG | ATYP | DST.ADDR | DST.PORT |   DATA   |
+ *   +----+------+------+----------+----------+----------+
+ *   | 2  |  1   |  1   | Variable |    2     | Variable |
+ */
+
+/**
+ * Parse the relay header at the front of a datagram. On success @addr receives
+ * the encapsulated address (the target for client->proxy datagrams) and
+ * *@hdr_len the offset where DATA begins, and 0 is returned.
+ *
+ * @return	0 on success; -EAGAIN if @len is shorter than the header;
+ *		-EINVAL on a malformed header; -ENOTSUP if FRAG != 0 (this
+ *		relay does not reassemble fragments).
+ */
+int gwp_socks5_udp_parse_hdr(const void *buf, size_t len,
+			     struct gwp_socks5_addr *addr, size_t *hdr_len);
+
+/**
+ * Build a relay header (RSV = 0, FRAG = 0, then @addr) into @buf, for wrapping a
+ * target's reply back to the client. On success *@hdr_len holds the header
+ * length. Returns 0, -ENOBUFS if @cap is too small, or -EINVAL on a bad @addr.
+ */
+int gwp_socks5_udp_build_hdr(const struct gwp_socks5_addr *addr, void *buf,
+			     size_t cap, size_t *hdr_len);
 
 /*
  * SOCKS5 client-side helpers.

--- a/src/gwproxy/tests/socks5.c
+++ b/src/gwproxy/tests/socks5.c
@@ -986,11 +986,133 @@ static void test_enobufs_combined_with_multi_state_at_once(void)
 	unlink(cred_file);
 }
 
+static void test_udp_associate(void)
+{
+	/* UDP ASSOCIATE with DST 0.0.0.0:0 (client source not yet known). */
+	static const uint8_t in[] = {
+		0x05, 0x03, 0x00, 0x01, /* VER, CMD=UDP ASSOCIATE, RSV, ATYP */
+		0x00, 0x00, 0x00, 0x00, /* DST.ADDR: 0.0.0.0 */
+		0x00, 0x00              /* DST.PORT: 0 */
+	};
+	static const struct gwp_socks5_addr bind_addr = {
+		.ver = GWP_SOCKS5_ATYP_IPV4,
+		.port = 0xaaaa,
+		.ip4 = { 0x7f, 0x00, 0x00, 0x01 }
+	};
+	struct gwp_socks5_conn *conn;
+	struct gwp_socks5_ctx *ctx;
+	size_t in_len, out_len;
+	uint8_t out[64];
+	int r;
+
+	test_socks5_init_ctx_no_auth(&ctx);
+	conn = test_socks5_alloc_conn(ctx);
+	test_socks5_do_handshake_no_auth(ctx, conn);
+
+	in_len = sizeof(in);
+	out_len = sizeof(out);
+	r = gwp_socks5_conn_handle_data(conn, in, &in_len, out, &out_len);
+	assert(!r);
+	assert(in_len == sizeof(in));
+	assert(out_len == 0);
+	assert(conn->state == GWP_SOCKS5_ST_CMD_UDP_ASSOCIATE);
+
+	/* Reply with the relay endpoint. */
+	out_len = sizeof(out);
+	r = gwp_socks5_conn_cmd_udp_associate_res(conn, &bind_addr,
+						  GWP_SOCKS5_REP_SUCCESS, out,
+						  &out_len);
+	assert(!r);
+	assert(out_len == 10);
+	assert(out[0] == 0x05);			/* VER */
+	assert(out[1] == 0x00);			/* REP: success */
+	assert(out[2] == 0x00);			/* RSV */
+	assert(out[3] == GWP_SOCKS5_ATYP_IPV4);	/* ATYP */
+	assert(!memcmp(&out[4], "\x7f\x00\x00\x01", 4));	/* BND.ADDR */
+	assert(!memcmp(&out[8], "\xaa\xaa", 2));		/* BND.PORT */
+	assert(conn->state == GWP_SOCKS5_ST_UDP_ASSOCIATED);
+	assert(ctx->nr_clients == 1);
+
+	gwp_socks5_conn_free(conn);
+	gwp_socks5_ctx_free(ctx);
+}
+
+static void test_udp_hdr_codec(void)
+{
+	struct gwp_socks5_addr a, got;
+	uint8_t buf[GWP_SOCKS5_UDP_HDR_MAX + 16];
+	uint8_t dg[128];
+	size_t hlen, plen;
+	int r;
+
+	/* IPv4 round-trip, with trailing DATA on parse. */
+	memset(&a, 0, sizeof(a));
+	a.ver = GWP_SOCKS5_ATYP_IPV4;
+	memcpy(a.ip4, "\x08\x08\x08\x08", 4);
+	memcpy(&a.port, "\x00\x35", 2);		/* 53 */
+	r = gwp_socks5_udp_build_hdr(&a, buf, sizeof(buf), &hlen);
+	assert(!r && hlen == 3 + 1 + 4 + 2);
+	assert(buf[0] == 0 && buf[1] == 0 && buf[2] == 0);
+	assert(buf[3] == GWP_SOCKS5_ATYP_IPV4);
+	memcpy(dg, buf, hlen);
+	memcpy(dg + hlen, "hello", 5);
+	r = gwp_socks5_udp_parse_hdr(dg, hlen + 5, &got, &plen);
+	assert(!r && plen == hlen);
+	assert(got.ver == GWP_SOCKS5_ATYP_IPV4);
+	assert(!memcmp(got.ip4, a.ip4, 4));
+	assert(!memcmp(&got.port, &a.port, 2));
+	assert(!memcmp(dg + plen, "hello", 5));
+
+	/* IPv6 round-trip. */
+	memset(&a, 0, sizeof(a));
+	a.ver = GWP_SOCKS5_ATYP_IPV6;
+	memcpy(a.ip6, "\x20\x01\x0d\xb8\x00\x00\x00\x00"
+		      "\x00\x00\x00\x00\x00\x00\x00\x01", 16);
+	memcpy(&a.port, "\x01\xbb", 2);		/* 443 */
+	r = gwp_socks5_udp_build_hdr(&a, buf, sizeof(buf), &hlen);
+	assert(!r && hlen == 3 + 1 + 16 + 2);
+	r = gwp_socks5_udp_parse_hdr(buf, hlen, &got, &plen);
+	assert(!r && plen == hlen && got.ver == GWP_SOCKS5_ATYP_IPV6);
+	assert(!memcmp(got.ip6, a.ip6, 16));
+
+	/* Domain round-trip. */
+	memset(&a, 0, sizeof(a));
+	a.ver = GWP_SOCKS5_ATYP_DOMAIN;
+	a.domain.len = 11;
+	memcpy(a.domain.str, "example.com", 12);
+	memcpy(&a.port, "\x00\x50", 2);
+	r = gwp_socks5_udp_build_hdr(&a, buf, sizeof(buf), &hlen);
+	assert(!r && hlen == 3 + 1 + 1 + 11 + 2);
+	r = gwp_socks5_udp_parse_hdr(buf, hlen, &got, &plen);
+	assert(!r && got.ver == GWP_SOCKS5_ATYP_DOMAIN && got.domain.len == 11);
+	assert(!memcmp(got.domain.str, "example.com", 11));
+
+	/* FRAG != 0 -> unsupported. */
+	memcpy(dg, "\x00\x00\x01\x01\x08\x08\x08\x08\x00\x35", 10);
+	r = gwp_socks5_udp_parse_hdr(dg, 10, &got, &plen);
+	assert(r == -ENOTSUP);
+
+	/* Truncated header -> need more. */
+	r = gwp_socks5_udp_parse_hdr(dg, 3, &got, &plen);
+	assert(r == -EAGAIN);
+
+	/* Unknown ATYP -> malformed. */
+	memcpy(dg, "\x00\x00\x00\x09\x00\x00\x00\x00", 8);
+	r = gwp_socks5_udp_parse_hdr(dg, 8, &got, &plen);
+	assert(r == -EINVAL);
+
+	/* Build into too small a buffer. */
+	r = gwp_socks5_udp_build_hdr(&a, buf, 4, &hlen);
+	assert(r == -ENOBUFS);
+}
+
 static void gwp_socks5_run_tests(void)
 {
 	size_t i;
 
 	for (i = 0; i < 5000; i++) {
+		test_udp_associate();
+		test_udp_hdr_codec();
 		test_connect_ipv4();
 		test_connect_ipv6();
 		test_connect_domain();

--- a/t/0043-socks5-udp.sh
+++ b/t/0043-socks5-udp.sh
@@ -5,8 +5,9 @@
 # issues UDP ASSOCIATE, and the proxy returns a bound UDP relay endpoint. The
 # client then sends SOCKS5-wrapped datagrams to that relay, which forwards them
 # to a UDP echo server and relays the replies back. Verify datagrams of several
-# sizes round-trip byte-exact, that the relay is torn down with its TCP control
-# connection, and that plain SOCKS5 CONNECT still works on the same port. The
+# sizes round-trip byte-exact, IPv4/IPv6 and cross-address-family targets all
+# relay (the relay socket is dual-stack), the relay is torn down with its TCP
+# control connection, and plain SOCKS5 CONNECT still works on the same port. The
 # relay is exercised on both event loops (epoll and, when built, io_uring).
 
 . "$(dirname "$0")/lib.sh"
@@ -14,79 +15,99 @@ require curl
 require python3
 require ss
 
-# Start the dual-purpose UDP echo server and wait until its socket is bound.
+udp_client() { python3 "$SERVERS_DIR/socks5_udp_client.py" "$@"; }
+
+wait_udp_bound() {			# $1=port
+	local i
+	for i in $(seq 1 50); do
+		ss -uanH "sport = :$1" 2>/dev/null | grep -q . && return 0
+		sleep 0.1
+	done
+	fail "UDP echo server did not bind on $1"
+}
+
+# IPv4 UDP echo server.
 ep="$(pick_port)"
 python3 "$SERVERS_DIR/udp_echo.py" 127.0.0.1 "$ep" \
 	>"$WORK/udp_echo.$ep.log" 2>&1 &
 _PIDS+=("$!")
-for i in $(seq 1 50); do
-	ss -uanH "sport = :$ep" 2>/dev/null | grep -q . && break
-	sleep 0.1
-	[ "$i" = 50 ] && fail "UDP echo server did not bind on $ep"
-done
+wait_udp_bound "$ep"
+
+# IPv6 UDP echo server (best-effort: skip the IPv6 cases where ::1 is absent).
+have_v6=0
+ep6="$(pick_port)"
+if python3 -c 'import socket,sys; socket.socket(socket.AF_INET6,socket.SOCK_DGRAM).bind(("::1",0))' 2>/dev/null; then
+	have_v6=1
+	python3 "$SERVERS_DIR/udp_echo.py" ::1 "$ep6" \
+		>"$WORK/udp_echo.$ep6.log" 2>&1 &
+	_PIDS+=("$!")
+	wait_udp_bound "$ep6"
+fi
 
 # A TCP HTTP origin for the coexisting CONNECT check.
 hp="$(pick_port)"
 make_payload "$WORK/payload.bin" 100000
 start_httpd "$hp" "$WORK" "1.1"
 
-pp="$(pick_port)"
-gwp_start "127.0.0.1:$pp" --as-socks5=1 --event-loop=epoll --nr-workers=2
+# Run the full relay matrix on one event loop.
+run_loop() {
+	local loop="$1" pp tp
 
-# (1) UDP ASSOCIATE relay: datagrams of assorted sizes echo back intact.
-python3 "$SERVERS_DIR/socks5_udp_client.py" "$pp" "$ep" 1 60 1400 9000 60000 \
-	|| fail "SOCKS5 UDP ASSOCIATE relay failed"
-
-# (2) A fresh association works after the first is gone (each run opens and
-#     closes its own control connection, exercising relay teardown).
-python3 "$SERVERS_DIR/socks5_udp_client.py" "$pp" "$ep" 200 \
-	|| fail "second SOCKS5 UDP association failed"
-
-# (2b) The association outlives the protocol-handshake timeout (the handshake
-#      timer must be disarmed once the relay is up). Use a short timeout and a
-#      client that sends a datagram after it would have fired.
-tp="$(pick_port)"
-gwp_start "127.0.0.1:$tp" --as-socks5=1 --event-loop=epoll --protocol-timeout=1
-GWP_TP="$GWP_PID"
-python3 "$SERVERS_DIR/socks5_udp_client.py" "$tp" "$ep" --delay 2.0 64 \
-	|| fail "UDP association did not survive the protocol timeout"
-kill "$GWP_TP" 2>/dev/null
-
-# (3) Coexistence: plain SOCKS5 CONNECT still works on the same port.
-curl -s --max-time 20 -x "socks5h://127.0.0.1:$pp" \
-	"http://127.0.0.1:$hp/payload.bin" -o "$WORK/out.bin" \
-	|| fail "SOCKS5 CONNECT on the UDP-capable port failed"
-assert_files_equal "$WORK/payload.bin" "$WORK/out.bin" \
-	"SOCKS5 CONNECT corrupted the payload"
-
-kill "$GWP_PID" 2>/dev/null
-
-# (4) The io_uring loop relays too (when built): repeat the round-trip, a fresh
-#     association, and the protocol-timeout survival check on that loop.
-if grep -q CONFIG_IO_URING "$ROOT/config.h" 2>/dev/null; then
+	# (1) IPv4 client -> IPv4 target: datagrams of assorted sizes echo back.
 	pp="$(pick_port)"
-	gwp_start "127.0.0.1:$pp" --as-socks5=1 --event-loop=io_uring --nr-workers=2
+	gwp_start "127.0.0.1:$pp" --as-socks5=1 --event-loop="$loop" --nr-workers=2
+	udp_client "$pp" "$ep" 1 60 1400 9000 60000 \
+		|| fail "$loop SOCKS5 UDP ASSOCIATE relay failed"
 
-	python3 "$SERVERS_DIR/socks5_udp_client.py" "$pp" "$ep" 1 60 1400 9000 60000 \
-		|| fail "io_uring SOCKS5 UDP ASSOCIATE relay failed"
-	python3 "$SERVERS_DIR/socks5_udp_client.py" "$pp" "$ep" 200 \
-		|| fail "second io_uring SOCKS5 UDP association failed"
+	# (2) A fresh association works after the first is gone (exercises the
+	#     relay teardown that each closed control connection triggers).
+	udp_client "$pp" "$ep" 200 \
+		|| fail "$loop second SOCKS5 UDP association failed"
 
-	# Coexistence: plain SOCKS5 CONNECT still works on the io_uring loop.
+	# (3) Cross-address family: an IPv4-connected client reaches an IPv6
+	#     target through the dual-stack relay socket.
+	if [ "$have_v6" = 1 ]; then
+		udp_client --target-host ::1 "$pp" "$ep6" 1 1400 60000 \
+			|| fail "$loop IPv4-client -> IPv6-target relay failed"
+	fi
+
+	# (4) Coexistence: plain SOCKS5 CONNECT still works on the same port.
 	curl -s --max-time 20 -x "socks5h://127.0.0.1:$pp" \
-		"http://127.0.0.1:$hp/payload.bin" -o "$WORK/out.iou.bin" \
-		|| fail "io_uring SOCKS5 CONNECT on the UDP-capable port failed"
-	assert_files_equal "$WORK/payload.bin" "$WORK/out.iou.bin" \
-		"io_uring SOCKS5 CONNECT corrupted the payload"
+		"http://127.0.0.1:$hp/payload.bin" -o "$WORK/out.$loop.bin" \
+		|| fail "$loop SOCKS5 CONNECT on the UDP-capable port failed"
+	assert_files_equal "$WORK/payload.bin" "$WORK/out.$loop.bin" \
+		"$loop SOCKS5 CONNECT corrupted the payload"
 	kill "$GWP_PID" 2>/dev/null
 
+	# (5) IPv6 client, to both IPv6 and (cross-family) IPv4 targets.
+	if [ "$have_v6" = 1 ]; then
+		pp="$(pick_port)"
+		gwp_start "[::1]:$pp" --as-socks5=1 --event-loop="$loop" \
+			--nr-workers=2
+		udp_client --proxy-host ::1 --target-host ::1 \
+			"$pp" "$ep6" 1 1400 60000 \
+			|| fail "$loop IPv6-client -> IPv6-target relay failed"
+		udp_client --proxy-host ::1 --target-host 127.0.0.1 \
+			"$pp" "$ep" 1 1400 60000 \
+			|| fail "$loop IPv6-client -> IPv4-target relay failed"
+		kill "$GWP_PID" 2>/dev/null
+	fi
+
+	# (6) The association outlives the protocol-handshake timeout (the
+	#     handshake timer must be disarmed once the relay is up).
 	tp="$(pick_port)"
-	gwp_start "127.0.0.1:$tp" --as-socks5=1 --event-loop=io_uring \
+	gwp_start "127.0.0.1:$tp" --as-socks5=1 --event-loop="$loop" \
 		--protocol-timeout=1
 	GWP_TP="$GWP_PID"
-	python3 "$SERVERS_DIR/socks5_udp_client.py" "$tp" "$ep" --delay 2.0 64 \
-		|| fail "io_uring UDP association did not survive the timeout"
+	udp_client "$tp" "$ep" --delay 2.0 64 \
+		|| fail "$loop UDP association did not survive the timeout"
 	kill "$GWP_TP" 2>/dev/null
+}
+
+run_loop epoll
+
+if grep -q CONFIG_IO_URING "$ROOT/config.h" 2>/dev/null; then
+	run_loop io_uring
 fi
 
 pass

--- a/t/0043-socks5-udp.sh
+++ b/t/0043-socks5-udp.sh
@@ -49,6 +49,11 @@ hp="$(pick_port)"
 make_payload "$WORK/payload.bin" 100000
 start_httpd "$hp" "$WORK" "1.1"
 
+# A standalone SOCKS5 proxy used only as an upstream for the chaining-refusal
+# check below (kept alive for the whole test via _PIDS).
+up="$(pick_port)"
+gwp_start "127.0.0.1:$up" --as-socks5=1 --event-loop=epoll --nr-workers=2
+
 # Run the full relay matrix on one event loop.
 run_loop() {
 	local loop="$1" pp tp
@@ -102,6 +107,19 @@ run_loop() {
 	udp_client "$tp" "$ep" --delay 2.0 64 \
 		|| fail "$loop UDP association did not survive the timeout"
 	kill "$GWP_TP" 2>/dev/null
+
+	# (7) UDP ASSOCIATE is refused when an upstream proxy is configured:
+	#     chaining UDP is unsupported and a local relay would bypass the
+	#     upstream, so the proxy must reply with a non-zero REP.
+	fp="$(pick_port)"
+	gwp_start "127.0.0.1:$fp" --as-socks5=1 --event-loop="$loop" \
+		--upstream-proxy="socks5://127.0.0.1:$up"
+	if udp_client "$fp" "$ep" 64 >"$WORK/upstream.$loop.log" 2>&1; then
+		fail "$loop UDP ASSOCIATE accepted with an upstream configured"
+	fi
+	grep -qi refused "$WORK/upstream.$loop.log" \
+		|| fail "$loop UDP ASSOCIATE upstream rejection lacked its error"
+	kill "$GWP_PID" 2>/dev/null
 }
 
 run_loop epoll

--- a/t/0043-socks5-udp.sh
+++ b/t/0043-socks5-udp.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# SOCKS5 UDP ASSOCIATE (RFC 1928): a client opens a TCP control connection,
+# issues UDP ASSOCIATE, and the proxy returns a bound UDP relay endpoint. The
+# client then sends SOCKS5-wrapped datagrams to that relay, which forwards them
+# to a UDP echo server and relays the replies back. Verify datagrams of several
+# sizes round-trip byte-exact on the epoll loop, that the relay is torn down
+# with its TCP control connection, and that plain SOCKS5 CONNECT still works on
+# the same port. UDP ASSOCIATE is epoll-only for now, so the io_uring loop must
+# refuse it with "command not supported".
+
+. "$(dirname "$0")/lib.sh"
+require curl
+require python3
+require ss
+
+# Start the dual-purpose UDP echo server and wait until its socket is bound.
+ep="$(pick_port)"
+python3 "$SERVERS_DIR/udp_echo.py" 127.0.0.1 "$ep" \
+	>"$WORK/udp_echo.$ep.log" 2>&1 &
+_PIDS+=("$!")
+for i in $(seq 1 50); do
+	ss -uanH "sport = :$ep" 2>/dev/null | grep -q . && break
+	sleep 0.1
+	[ "$i" = 50 ] && fail "UDP echo server did not bind on $ep"
+done
+
+# A TCP HTTP origin for the coexisting CONNECT check.
+hp="$(pick_port)"
+make_payload "$WORK/payload.bin" 100000
+start_httpd "$hp" "$WORK" "1.1"
+
+pp="$(pick_port)"
+gwp_start "127.0.0.1:$pp" --as-socks5=1 --event-loop=epoll --nr-workers=2
+
+# (1) UDP ASSOCIATE relay: datagrams of assorted sizes echo back intact.
+python3 "$SERVERS_DIR/socks5_udp_client.py" "$pp" "$ep" 1 60 1400 9000 60000 \
+	|| fail "SOCKS5 UDP ASSOCIATE relay failed"
+
+# (2) A fresh association works after the first is gone (each run opens and
+#     closes its own control connection, exercising relay teardown).
+python3 "$SERVERS_DIR/socks5_udp_client.py" "$pp" "$ep" 200 \
+	|| fail "second SOCKS5 UDP association failed"
+
+# (2b) The association outlives the protocol-handshake timeout (the handshake
+#      timer must be disarmed once the relay is up). Use a short timeout and a
+#      client that sends a datagram after it would have fired.
+tp="$(pick_port)"
+gwp_start "127.0.0.1:$tp" --as-socks5=1 --event-loop=epoll --protocol-timeout=1
+GWP_TP="$GWP_PID"
+python3 "$SERVERS_DIR/socks5_udp_client.py" "$tp" "$ep" --delay 2.0 64 \
+	|| fail "UDP association did not survive the protocol timeout"
+kill "$GWP_TP" 2>/dev/null
+
+# (3) Coexistence: plain SOCKS5 CONNECT still works on the same port.
+curl -s --max-time 20 -x "socks5h://127.0.0.1:$pp" \
+	"http://127.0.0.1:$hp/payload.bin" -o "$WORK/out.bin" \
+	|| fail "SOCKS5 CONNECT on the UDP-capable port failed"
+assert_files_equal "$WORK/payload.bin" "$WORK/out.bin" \
+	"SOCKS5 CONNECT corrupted the payload"
+
+kill "$GWP_PID" 2>/dev/null
+
+# (4) io_uring is epoll-only for UDP ASSOCIATE: it must refuse with REP 0x07.
+if grep -q CONFIG_IO_URING "$ROOT/config.h" 2>/dev/null; then
+	pp="$(pick_port)"
+	gwp_start "127.0.0.1:$pp" --as-socks5=1 --event-loop=io_uring --nr-workers=2
+	if python3 "$SERVERS_DIR/socks5_udp_client.py" "$pp" "$ep" 64 \
+		>"$WORK/iou.log" 2>&1; then
+		fail "io_uring accepted UDP ASSOCIATE (should be refused)"
+	fi
+	grep -qi 'refused' "$WORK/iou.log" \
+		|| fail "io_uring UDP ASSOCIATE rejection lacked the expected error"
+	kill "$GWP_PID" 2>/dev/null
+fi
+
+pass

--- a/t/0043-socks5-udp.sh
+++ b/t/0043-socks5-udp.sh
@@ -5,10 +5,9 @@
 # issues UDP ASSOCIATE, and the proxy returns a bound UDP relay endpoint. The
 # client then sends SOCKS5-wrapped datagrams to that relay, which forwards them
 # to a UDP echo server and relays the replies back. Verify datagrams of several
-# sizes round-trip byte-exact on the epoll loop, that the relay is torn down
-# with its TCP control connection, and that plain SOCKS5 CONNECT still works on
-# the same port. UDP ASSOCIATE is epoll-only for now, so the io_uring loop must
-# refuse it with "command not supported".
+# sizes round-trip byte-exact, that the relay is torn down with its TCP control
+# connection, and that plain SOCKS5 CONNECT still works on the same port. The
+# relay is exercised on both event loops (epoll and, when built, io_uring).
 
 . "$(dirname "$0")/lib.sh"
 require curl
@@ -62,17 +61,32 @@ assert_files_equal "$WORK/payload.bin" "$WORK/out.bin" \
 
 kill "$GWP_PID" 2>/dev/null
 
-# (4) io_uring is epoll-only for UDP ASSOCIATE: it must refuse with REP 0x07.
+# (4) The io_uring loop relays too (when built): repeat the round-trip, a fresh
+#     association, and the protocol-timeout survival check on that loop.
 if grep -q CONFIG_IO_URING "$ROOT/config.h" 2>/dev/null; then
 	pp="$(pick_port)"
 	gwp_start "127.0.0.1:$pp" --as-socks5=1 --event-loop=io_uring --nr-workers=2
-	if python3 "$SERVERS_DIR/socks5_udp_client.py" "$pp" "$ep" 64 \
-		>"$WORK/iou.log" 2>&1; then
-		fail "io_uring accepted UDP ASSOCIATE (should be refused)"
-	fi
-	grep -qi 'refused' "$WORK/iou.log" \
-		|| fail "io_uring UDP ASSOCIATE rejection lacked the expected error"
+
+	python3 "$SERVERS_DIR/socks5_udp_client.py" "$pp" "$ep" 1 60 1400 9000 60000 \
+		|| fail "io_uring SOCKS5 UDP ASSOCIATE relay failed"
+	python3 "$SERVERS_DIR/socks5_udp_client.py" "$pp" "$ep" 200 \
+		|| fail "second io_uring SOCKS5 UDP association failed"
+
+	# Coexistence: plain SOCKS5 CONNECT still works on the io_uring loop.
+	curl -s --max-time 20 -x "socks5h://127.0.0.1:$pp" \
+		"http://127.0.0.1:$hp/payload.bin" -o "$WORK/out.iou.bin" \
+		|| fail "io_uring SOCKS5 CONNECT on the UDP-capable port failed"
+	assert_files_equal "$WORK/payload.bin" "$WORK/out.iou.bin" \
+		"io_uring SOCKS5 CONNECT corrupted the payload"
 	kill "$GWP_PID" 2>/dev/null
+
+	tp="$(pick_port)"
+	gwp_start "127.0.0.1:$tp" --as-socks5=1 --event-loop=io_uring \
+		--protocol-timeout=1
+	GWP_TP="$GWP_PID"
+	python3 "$SERVERS_DIR/socks5_udp_client.py" "$tp" "$ep" --delay 2.0 64 \
+		|| fail "io_uring UDP association did not survive the timeout"
+	kill "$GWP_TP" 2>/dev/null
 fi
 
 pass

--- a/t/servers/socks5_udp_client.py
+++ b/t/servers/socks5_udp_client.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# SOCKS5 UDP ASSOCIATE client for the integration test. Opens a TCP control
+# connection to the proxy, issues UDP ASSOCIATE, then relays datagrams of the
+# requested sizes to a UDP echo server through the proxy's relay socket and
+# checks each is echoed back byte-exact. Args: proxy_port echo_port size...
+import socket, struct, sys, time
+
+argv = sys.argv[1:]
+delay = 0.0
+if '--delay' in argv:
+    i = argv.index('--delay')
+    delay = float(argv[i + 1])
+    del argv[i:i + 2]
+pp = int(argv[0]); ep = int(argv[1])
+sizes = [int(x) for x in argv[2:]] or [64]
+
+t = socket.create_connection(('127.0.0.1', pp)); t.settimeout(10)
+t.sendall(b'\x05\x01\x00')
+assert t.recv(2) == b'\x05\x00', 'method selection failed'
+# UDP ASSOCIATE, DST 0.0.0.0:0 (source not yet known)
+t.sendall(b'\x05\x03\x00\x01\x00\x00\x00\x00\x00\x00')
+rep = t.recv(10)
+assert len(rep) == 10 and rep[0] == 5, 'bad assoc reply'
+assert rep[1] == 0, 'UDP ASSOCIATE refused (REP=0x%02x)' % rep[1]
+bnd_ip = socket.inet_ntoa(rep[4:8]); bnd_port = struct.unpack('!H', rep[8:10])[0]
+
+if delay:
+    time.sleep(delay)			# outlast the handshake timeout
+u = socket.socket(socket.AF_INET, socket.SOCK_DGRAM); u.settimeout(2)
+hdr = b'\x00\x00\x00\x01' + socket.inet_aton('127.0.0.1') + struct.pack('!H', ep)
+for sz in sizes:
+    payload = bytes((i * 7 + sz) & 0xff for i in range(sz))
+    got = None
+    for _ in range(5):			# UDP is lossy; retry a few times
+        u.sendto(hdr + payload, (bnd_ip, bnd_port))
+        try:
+            data, _ = u.recvfrom(65535)
+        except socket.timeout:
+            continue
+        assert data[:4] == b'\x00\x00\x00\x01', 'bad reply header'
+        got = data[10:]
+        break
+    assert got == payload, 'echo mismatch at size %d' % sz
+print('OK: %d datagram size(s) relayed' % len(sizes))

--- a/t/servers/socks5_udp_client.py
+++ b/t/servers/socks5_udp_client.py
@@ -4,32 +4,83 @@
 # SOCKS5 UDP ASSOCIATE client for the integration test. Opens a TCP control
 # connection to the proxy, issues UDP ASSOCIATE, then relays datagrams of the
 # requested sizes to a UDP echo server through the proxy's relay socket and
-# checks each is echoed back byte-exact. Args: proxy_port echo_port size...
+# checks each is echoed back byte-exact.
+#
+# Usage: socks5_udp_client.py [--delay S] [--proxy-host H] [--target-host H] \
+#            proxy_port echo_port size...
+# The proxy and target hosts default to 127.0.0.1; pass an IPv6 literal (e.g.
+# ::1) to exercise IPv6 and cross-address-family relaying.
 import socket, struct, sys, time
 
 argv = sys.argv[1:]
 delay = 0.0
-if '--delay' in argv:
-    i = argv.index('--delay')
-    delay = float(argv[i + 1])
-    del argv[i:i + 2]
+proxy_host = '127.0.0.1'
+target_host = '127.0.0.1'
+
+
+def take_opt(name):
+    if name in argv:
+        i = argv.index(name)
+        val = argv[i + 1]
+        del argv[i:i + 2]
+        return val
+    return None
+
+
+v = take_opt('--delay')
+if v is not None:
+    delay = float(v)
+v = take_opt('--proxy-host')
+if v is not None:
+    proxy_host = v
+v = take_opt('--target-host')
+if v is not None:
+    target_host = v
+
 pp = int(argv[0]); ep = int(argv[1])
 sizes = [int(x) for x in argv[2:]] or [64]
 
-t = socket.create_connection(('127.0.0.1', pp)); t.settimeout(10)
+
+def atyp_addr(host):
+    """SOCKS5 ATYP + packed address for a numeric host."""
+    if ':' in host:
+        return b'\x04' + socket.inet_pton(socket.AF_INET6, host)
+    return b'\x01' + socket.inet_aton(host)
+
+
+def skip_reply_hdr(data):
+    """Return the payload offset after a SOCKS5 UDP reply header."""
+    atyp = data[3]
+    if atyp == 1:
+        return 4 + 4 + 2
+    if atyp == 4:
+        return 4 + 16 + 2
+    raise AssertionError('bad reply ATYP 0x%02x' % atyp)
+
+
+pfam = socket.AF_INET6 if ':' in proxy_host else socket.AF_INET
+t = socket.socket(pfam, socket.SOCK_STREAM)
+t.settimeout(10)
+t.connect((proxy_host, pp))
 t.sendall(b'\x05\x01\x00')
 assert t.recv(2) == b'\x05\x00', 'method selection failed'
-# UDP ASSOCIATE, DST 0.0.0.0:0 (source not yet known)
+# UDP ASSOCIATE, DST 0.0.0.0:0 (source not yet known).
 t.sendall(b'\x05\x03\x00\x01\x00\x00\x00\x00\x00\x00')
-rep = t.recv(10)
-assert len(rep) == 10 and rep[0] == 5, 'bad assoc reply'
+rep = t.recv(4)
+assert len(rep) == 4 and rep[0] == 5, 'bad assoc reply'
 assert rep[1] == 0, 'UDP ASSOCIATE refused (REP=0x%02x)' % rep[1]
-bnd_ip = socket.inet_ntoa(rep[4:8]); bnd_port = struct.unpack('!H', rep[8:10])[0]
+if rep[3] == 1:
+    bnd_ip = socket.inet_ntoa(t.recv(4)); bfam = socket.AF_INET
+elif rep[3] == 4:
+    bnd_ip = socket.inet_ntop(socket.AF_INET6, t.recv(16)); bfam = socket.AF_INET6
+else:
+    raise AssertionError('bad BND ATYP 0x%02x' % rep[3])
+bnd_port = struct.unpack('!H', t.recv(2))[0]
 
 if delay:
     time.sleep(delay)			# outlast the handshake timeout
-u = socket.socket(socket.AF_INET, socket.SOCK_DGRAM); u.settimeout(2)
-hdr = b'\x00\x00\x00\x01' + socket.inet_aton('127.0.0.1') + struct.pack('!H', ep)
+u = socket.socket(bfam, socket.SOCK_DGRAM); u.settimeout(2)
+hdr = b'\x00\x00\x00' + atyp_addr(target_host) + struct.pack('!H', ep)
 for sz in sizes:
     payload = bytes((i * 7 + sz) & 0xff for i in range(sz))
     got = None
@@ -39,8 +90,7 @@ for sz in sizes:
             data, _ = u.recvfrom(65535)
         except socket.timeout:
             continue
-        assert data[:4] == b'\x00\x00\x00\x01', 'bad reply header'
-        got = data[10:]
+        got = data[skip_reply_hdr(data):]
         break
     assert got == payload, 'echo mismatch at size %d' % sz
 print('OK: %d datagram size(s) relayed' % len(sizes))

--- a/t/servers/udp_echo.py
+++ b/t/servers/udp_echo.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-2.0-only
+# A trivial UDP echo server for the SOCKS5 UDP ASSOCIATE test.
+import socket, sys
+
+fam = socket.AF_INET6 if ':' in sys.argv[1] else socket.AF_INET
+s = socket.socket(fam, socket.SOCK_DGRAM)
+s.bind((sys.argv[1], int(sys.argv[2])))
+while True:
+    data, addr = s.recvfrom(65535)
+    s.sendto(data, addr)


### PR DESCRIPTION
Hi Chief,

SOCKS5 UDP ASSOCIATE (RFC 1928) for gwproxy. SOCKS5 was TCP CONNECT only
until now. This contains:

- The protocol layer in socks5.c: CMD=0x03 dispatch and a stateless
  datagram header codec (gwp_socks5_udp_parse_hdr/_build_hdr), with unit
  tests. Also fixes BND.PORT in the command reply, which is a raw __be16
  and was being byte-swapped a second time.

- The epoll relay: one bound UDP socket per association, kept in
  gcp->udp_fd and serviced in bounded 64-datagram batches out of a
  per-worker scratch buffer, with the datagram received at an offset so
  the reply header can be prepended in place. The client is pinned from
  its first datagram and validated against the TCP control connection.

- The io_uring relay: async recvmsg/sendmsg, so the scratch has to be
  per-connection rather than per-worker, and exactly one recv or send is
  in flight per association. Teardown cancels the fd and drains the
  -ECANCELED before the finalizer frees anything.

- Cross-address-family relaying: the relay socket is a dual-stack
  AF_INET6 socket bound to in6addr_any, since a single-family bind
  cannot egress the other family. BND.ADDR comes from the control
  connection and BND.PORT from the relay.

- UDP ASSOCIATE is refused with REP 0x07 when an upstream proxy is
  configured. Chaining UDP would need a SOCKS5-UDP client toward the
  upstream, and an HTTP upstream cannot carry UDP at all; relaying
  locally would quietly bypass the chain.

Two bugs found by review were fixed before this went out: the handshake
timer was not disarmed and would fire and tear down a live relay, and an
off-path host could hijack the client pin.

Domain-name (ATYP=0x03) targets are deliberately not implemented yet;
such datagrams are dropped. t/0043-socks5-udp.sh covers the full
v4/v6 client x v4/v6 target matrix on both event loops.

Please pull, tq!

```
The following changes since commit ae8b79ee898186c4bbd0799af17b82412db402d0:

  man: Document --upstream-proxy and HTTP upstream chaining (2026-07-16 23:24:37 +0700)

are available in the Git repository at:

  https://github.com/alviroiskandar/gwproxy.git tags/gwp-2026-07-29-udp

for you to fetch changes up to 79d135a34ec8a59d5a9f74c970d79276e74ebf33:

  socks5: Refuse UDP ASSOCIATE when an upstream proxy is configured (2026-07-17 04:11:49 +0700)

----------------------------------------------------------------
gwp-2026-07-29-udp

----------------------------------------------------------------
Alviro Iskandar Setiawan (6):
      socks5: Parse UDP ASSOCIATE and add the relay datagram codec
      socks5: Fix BND.PORT byte order in the command reply
      epoll: Add SOCKS5 UDP ASSOCIATE relay
      io_uring: Add SOCKS5 UDP ASSOCIATE relay
      socks5: Relay UDP ASSOCIATE to cross-address-family targets
      socks5: Refuse UDP ASSOCIATE when an upstream proxy is configured

 README                         |   8 +-
 man/gwproxy.1                  |   6 +-
 src/gwproxy/ev/epoll.c         | 174 ++++++++++++++++++++++++++++
 src/gwproxy/ev/io_uring.c      | 246 +++++++++++++++++++++++++++++++++++++++-
 src/gwproxy/gwproxy.c          | 219 ++++++++++++++++++++++++++++++++++-
 src/gwproxy/gwproxy.h          |  72 ++++++++++++
 src/gwproxy/socks5.c           | 162 +++++++++++++++++++++++---
 src/gwproxy/socks5.h           |  50 ++++++++
 src/gwproxy/tests/socks5.c     | 122 ++++++++++++++++++++
 t/0043-socks5-udp.sh           | 131 +++++++++++++++++++++
 t/servers/socks5_udp_client.py |  96 ++++++++++++++++
 t/servers/udp_echo.py          |  11 ++
 12 files changed, 1271 insertions(+), 26 deletions(-)
 create mode 100755 t/0043-socks5-udp.sh
 create mode 100755 t/servers/socks5_udp_client.py
 create mode 100755 t/servers/udp_echo.py

-- 
Alviro Iskandar Setiawan
```